### PR TITLE
Flatten global translations for Open SDG 0.9.1 or higher

### DIFF
--- a/scripts/batch/flatten_global_translations.py
+++ b/scripts/batch/flatten_global_translations.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Flatten stuff.
+"""
+
+import os
+import yaml
+
+def export_yaml(data, filename):
+    with open(filename, 'w') as outfile:
+        yaml.dump(data, outfile, default_flow_style=False, allow_unicode=True)
+
+languages = ['de', 'en']
+fields = {
+    'global_goals': ['short', 'title'],
+    'global_targets': ['title'],
+    'global_indicators': ['title']
+}
+for language in languages:
+    for filename in fields:
+        filepath = os.path.join('translations', language, filename + '.yml')
+        flattened = {}
+        with open(filepath, 'r') as stream:
+            yamldata = yaml.load(stream)
+            for key in yamldata:
+                for child in fields[filename]:
+                    if child in yamldata[key]:
+                        flat_key = key + '-' + child
+                        flattened[flat_key] = yamldata[key][child]
+        export_yaml(flattened, filepath)

--- a/translations/de/global_goals.yml
+++ b/translations/de/global_goals.yml
@@ -1,66 +1,50 @@
-'1':
-  short: Keine Armut
-  title: Armut in allen ihren Formen und überall beenden
-'10':
-  short: Weniger Ungleichheiten
-  title: Ungleichheit in und zwischen Ländern verringern
-'11':
-  short: Nachhaltige Städte und Gemeinden
-  title: Städte und Siedlungen inklusiv, sicher, widerstandsfähig und nachhaltig gestalten
-'12':
-  short: Verantwortungsvolle Konsum- und Produktionsmuster
-  title: Nachhaltige Konsum- und Produktionsmuster sicherstellen
-'13':
-  short: Maßnahmen zum Klimaschutz
-  title: Umgehend Maßnahmen zur Bekämpfung des Klimawandels und seiner Auswirkungen
-    ergreifen
-'14':
-  short: Leben unter Wasser
-  title: Ozeane, Meere und Meeresressourcen im Sinne nachhaltiger Entwicklung erhalten
-    und nachhaltig nutzen
-'15':
-  short: Leben an Land
-  title: 'Landökosysteme schützen, wiederherstellen und ihre nachhaltige Nutzung fördern,
-    Wälder nachhaltig bewirtschaften, Wüstenbildung bekämpfen, Bodendegradation beenden
-    und umkehren und dem Verlust der biologischen Vielfalt ein Ende setzen'
-'16':
-  short: Frieden, Gerechtigkeit und starke Institutionen
-  title: Friedliche und inklusive Gesellschaften für eine nachhaltige Entwicklung
-    fördern, allen Menschen Zugang zur Justiz ermöglichen und leistungsfähige, rechenschaftspflichtige
-    und inklusive Institutionen auf allen Ebenen aufbauen
-'17':
-  short: Partnerschaften zur Erreichung der Ziele
-  title: Umsetzungsmittel stärken und die Globale Partnerschaft für nachhaltige Entwicklung
-    mit neuem Leben erfüllen
-'2':
-  short: Kein Hunger
-  title: Den Hunger beenden, Ernährungssicherheit und eine bessere Ernährung erreichen
-    und eine nachhaltige Landwirtschaft fördern
-'3':
-  short: Gesundheit und Wohlergehen
-  title: Ein gesundes Leben für alle Menschen jeden Alters gewährleisten und ihr Wohlergehen
-    fördern
-'4':
-  short: Hochwertige Bildung
-  title: Inklusive, gleichberechtigte und hochwertige Bildung gewährleisten und Möglichkeiten
-    lebenslangen Lernens für alle fördern
-'5':
-  short: Geschlechtergleichstellung
-  title: Geschlechtergleichstellung erreichen und alle Frauen und Mädchen zur Selbstbestimmung
-    befähigen
-'6':
-  short: Sauberes Wasser und Sanitärversorgung
-  title: Verfügbarkeit und nachhaltige Bewirtschaftung von Wasser und Sanitärversorgung
-    für alle gewährleisten
-'7':
-  short: Bezahlbare und saubere Energie
-  title: Zugang zu bezahlbarer, verlässlicher, nachhaltiger und moderner Energie für
-    alle sichern
-'8':
-  short: Menschenwürdige Arbeit und Wirtschaftswachstum
-  title: Dauerhaftes, breitenwirksames und nachhaltiges Wirtschaftswachstum, produktive
-    Vollbeschäftigung und menschenwürdige Arbeit für alle fördern
-'9':
-  short: Industrie, Innovationen und Infrastruktur
-  title: Eine widerstandsfähige Infrastruktur aufbauen, breitenwirksame und nachhaltige
-    Industrialisierung fördern und Innovationen unterstützen
+1-short: Keine Armut
+1-title: Armut in allen ihren Formen und überall beenden
+10-short: Weniger Ungleichheiten
+10-title: Ungleichheit in und zwischen Ländern verringern
+11-short: Nachhaltige Städte und Gemeinden
+11-title: Städte und Siedlungen inklusiv, sicher, widerstandsfähig und nachhaltig
+  gestalten
+12-short: Verantwortungsvolle Konsum- und Produktionsmuster
+12-title: Nachhaltige Konsum- und Produktionsmuster sicherstellen
+13-short: Maßnahmen zum Klimaschutz
+13-title: Umgehend Maßnahmen zur Bekämpfung des Klimawandels und seiner Auswirkungen
+  ergreifen
+14-short: Leben unter Wasser
+14-title: Ozeane, Meere und Meeresressourcen im Sinne nachhaltiger Entwicklung erhalten
+  und nachhaltig nutzen
+15-short: Leben an Land
+15-title: Landökosysteme schützen, wiederherstellen und ihre nachhaltige Nutzung fördern,
+  Wälder nachhaltig bewirtschaften, Wüstenbildung bekämpfen, Bodendegradation beenden
+  und umkehren und dem Verlust der biologischen Vielfalt ein Ende setzen
+16-short: Frieden, Gerechtigkeit und starke Institutionen
+16-title: Friedliche und inklusive Gesellschaften für eine nachhaltige Entwicklung
+  fördern, allen Menschen Zugang zur Justiz ermöglichen und leistungsfähige, rechenschaftspflichtige
+  und inklusive Institutionen auf allen Ebenen aufbauen
+17-short: Partnerschaften zur Erreichung der Ziele
+17-title: Umsetzungsmittel stärken und die Globale Partnerschaft für nachhaltige Entwicklung
+  mit neuem Leben erfüllen
+2-short: Kein Hunger
+2-title: Den Hunger beenden, Ernährungssicherheit und eine bessere Ernährung erreichen
+  und eine nachhaltige Landwirtschaft fördern
+3-short: Gesundheit und Wohlergehen
+3-title: Ein gesundes Leben für alle Menschen jeden Alters gewährleisten und ihr Wohlergehen
+  fördern
+4-short: Hochwertige Bildung
+4-title: Inklusive, gleichberechtigte und hochwertige Bildung gewährleisten und Möglichkeiten
+  lebenslangen Lernens für alle fördern
+5-short: Geschlechtergleichstellung
+5-title: Geschlechtergleichstellung erreichen und alle Frauen und Mädchen zur Selbstbestimmung
+  befähigen
+6-short: Sauberes Wasser und Sanitärversorgung
+6-title: Verfügbarkeit und nachhaltige Bewirtschaftung von Wasser und Sanitärversorgung
+  für alle gewährleisten
+7-short: Bezahlbare und saubere Energie
+7-title: Zugang zu bezahlbarer, verlässlicher, nachhaltiger und moderner Energie für
+  alle sichern
+8-short: Menschenwürdige Arbeit und Wirtschaftswachstum
+8-title: Dauerhaftes, breitenwirksames und nachhaltiges Wirtschaftswachstum, produktive
+  Vollbeschäftigung und menschenwürdige Arbeit für alle fördern
+9-short: Industrie, Innovationen und Infrastruktur
+9-title: Eine widerstandsfähige Infrastruktur aufbauen, breitenwirksame und nachhaltige
+  Industrialisierung fördern und Innovationen unterstützen

--- a/translations/de/global_indicators.yml
+++ b/translations/de/global_indicators.yml
@@ -1,721 +1,510 @@
-1.1.1:
-  title: Anteil der Bevölkerung, die unter der internationalen Armutsgrenze lebt,
-    nach Geschlecht, Alter, Erwerbsstatus  und geographischer Lage (urban/rural)
-1.2.1:
-  title: Anteil der Bevölkerung, die unter der nationalen Armutsgrenze lebt, nach
-    Geschlecht und Alter
-1.2.2:
-  title: Anteil der Männer, Frauen und Kinder jeden Alters, die in Armut in all ihren
-    Dimensionen gemäß nationaler Definitionen leben
-1.3.1:
-  title: Anteil der Bevölkerung, die durch soziale Sicherungssysteme abgesichert ist, nach Geschlecht, untergliedert nach Kindern, Arbeitslosen, älteren Personen, Menschen mit Behinderungen, Schwangeren, Neugeborenen, Opfern von Arbeitsunfällen sowie Armen und Schwachen
-1.4.1:
-  title: Anteil der Bevölkerung, die in Haushalten mit Zugang zur Grundversorgung lebt
-1.4.2:
-  title: Anteil der erwachsenen Gesamtbevölkerung mit gesicherter Verfügungsgewalt
-    über Grundeigentum, (a) mit gesetzlich anerkannter Dokumentation und (b) die ihr
-    Eigentumsrecht als sicher erachten, nach Geschlecht und Art der Eigentumsverhältnisse
-1.5.1:
-  title: Anzahl der infolge von Katastrophen getöteten, vermissten und direkt betroffenen
-    Personen, je 100&nbsp;000 Einwohner
-1.5.2:
-  title: Unmittelbarer wirtschaftlicher Schaden infolge von Katastrophen, im Verhältnis
-    zum globalen Bruttoinlandsprodukt (BIP)
-1.5.3:
-  title: Anzahl der Staaten, die nationale Strategien zur Reduzierung des Katastrophenrisikos
-    in Einklang mit dem Sendai-Rahmenwerk zur Katastrophenvorsorge 2015-2030 verabschiedet
-    und umgesetzt haben
-1.5.4:
-  title: Anteil der lokalen Regierungen, die lokale Strategien zur Reduzierung des
-    Katastrophenrisikos in Einklang mit den nationalen Strategien zur Katastrophenvorsorge
-    verabschiedet und umgesetzt haben
-1.a.1:
-  title: Anteil der inländisch erwirtschafteten Ressourcen, die von der Regierung
-    direkt für Programme zur Armutsbekämpfung bereitgestellt werden
-1.a.2:
-  title: Anteil der gesamten staatlichen Ausgaben für Grundleistungen (Bildung, Gesundheit
-    und soziale Sicherung)
-1.a.3:
-  title: Summe der gesamten Zuschüsse und nicht schuldenwirksamen Zuflüsse, die direkt
-    Programmen zur Armutsbekämpfung zugewiesen werden, im Verhältnis zum BIP
-1.b.1:
-  title: Anteil der wiederkehrenden staatlichen und Investitionsausgaben für Sektoren,
-    die überdurchschnittlich Frauen, Arme und benachteiligte Gruppen begünstigen
-10.1.1:
-  title: Wachstumsraten der Haushaltsausgaben oder -einkommen pro Kopf der unteren
-    40&nbsp;Prozent der Bevölkerung und der Gesamtbevölkerung
-10.2.1:
-  title: Anteil der Bevölkerung, die mit weniger als 50% des Medianeinkommens leben,
-    nach Geschlecht, Alter und Menschen mit Behinderungen
-10.3.1:
-  title: Anteil der Bevölkerung, die angibt sich in den vergangenen 12&nbsp;Monaten persönlich
-    diskriminiert oder belästigt gefühlt zu haben basierend auf einem Diskriminierungsgrund,
-    der nach internationalem Menschenrechtsgesetzen verboten ist
-10.4.1:
-  title: Anteil des Arbeitsnehmerentgelts am BIP, bestehend aus Löhnen, Gehältern
-    und Sozialversicherungsbeiträgen
-10.5.1:
-  title: Financial Soundness Indicators
-10.6.1:
-  title: Anteil der Mitglieder und Stimmrechte der Entwicklungsländer in internationalen
-    Organisationen
-10.7.1:
-  title: Von Beschäftigten getragene Einstellungskosten als Anteil des monatlichen Einkommens
-    des Bestimmungslandes
-10.7.2:
-  title: Anzahl der Staaten mit Migrationspolitik, die eine ordnungsgemäße sichere, regelmäßige und verantwortungsbewusste Migration und Mobilität von Menschen ermöglicht
-10.a.1:
-  title: Anteil der Zolltarife auf Einfuhren aus den am wenigsten entwickelten Ländern
-    sowie Entwicklungsländer mit Zollfreiheit
-10.b.1:
-  title: Gesamte Finanzströme für Entwicklung, nach Nehmer- und Geberländern und Art des Zahlungsstroms (z. B. öffentliche Entwicklungszusammenarbeit (ODA), ausländische Direktinvestitionen und sonstige Finanzströme)
-10.c.1:
-  title: Überweisungskosten  als Anteil am überwiesenen Betrag
-11.1.1:
-  title: Anteil der urbanen Bevölkerung, die in Slums, informellen Siedlungen oder unangemessenen Unterkünften lebt
-11.2.1:
-  title: Anteil der Bevölkerung, die einen angemessenen Zugang zu öffentlichen Verkehrsmitteln hat, nach Geschlecht, Alter und Menschen mit Behinderungen
-11.3.1:
-  title: Verhältnis der Flächennutzungs- zur Bevölkerungswachstumsrate
-11.3.2:
-  title: Anteil der Städte mit einer direkten Beteiligungsstruktur der Zivilgesellschaft
-    an der Stadtplanung und -verwaltung, die regelmäßig und demokratisch arbeitet
-11.4.1:
-  title: Gesamtausgaben (öffentlich und privat) pro Kopf für die Bewahrung, den Schutz
-    und die Erhaltung des Kultur- und Naturerbes, nach Art des Erbes (Kultur, Natur,
-    gemischt und durch das Welterbezentrum ernannt), Regierungsebene (national, regional
-    und lokal/kommunal), Art der Ausgabe (Betriebsausgabe/Investition) und Art der
-    privaten Finanzierung (Sachspenden, privater gemeinnütziger Sektor und Förderer)
-11.5.1:
-  title: Anzahl der infolge von Katastrophen getöteten, vermissten und direkt betroffenen
-    Personen, je 100&nbsp;000 Einwohner
-11.5.2:
-  title: Unmittelbarer wirtschaftlicher Schaden im Verhältnis zum globalen BIP, Schäden
-    kritischer Infrastruktur und Anzahl der Ausfälle von Grundversorgungsleistungen
-    infolge von Katastrophen
-11.6.1:
-  title: Anteil der Siedlungsabfälle, die regelmäßig gesammelt und ordnungsgemäß entsorgt
-    werden, an den insgesamt erzeugten Siedlungsabfällen, nach Städten
-11.6.2:
-  title: Jahresmittelwerte für Feinstaub (z. B. PM2,5 und PM10) in Städten (bevölkerungsgewichtet)
-11.7.1:
-  title: Durchschnittlicher Anteil der bebauten Fläche in Städten, die als Freifläche
-    öffentlich zugänglich ist, nach Geschlecht, Alter und Menschen mit Behinderungen
-11.7.2:
-  title: Anteil der Personen, die in den vergangenen 12&nbsp;Monaten Opfer körperlicher
-    oder sexueller Belästigung wurden, nach Geschlecht, Alter, Behinderungsstatus
-    und Ort des Geschehens
-11.a.1:
-  title: Anteil der Bevölkerung in Städten, die Stadt- und Regionalentwicklungspläne
-    unter Berücksichtigung der Bevölkerungsprognosen und des Ressourcenbedarfs umsetzen,
-    nach Größe der Stadt
-11.b.1:
-  title: Anzahl der Staaten, die nationale Strategien zur Reduzierung des Katastrophenrisikos
-    in Einklang mit dem Sendai-Rahmenwerk zur Katastrophenvorsorge 2015-2030 verabschiedet
-    und umgesetzt haben
-11.b.2:
-  title: Anteil der lokalen Regierungen, die lokale Strategien zur Reduzierung des
-    Katastrophenrisikos in Einklang mit den nationalen Strategien zur Katastrophenvorsorge
-    verabschiedet und umgesetzt haben
-11.c.1:
-  title: Anteil der finanziellen Unterstützung, die den am wenigsten entwickelten
-    Ländern für den Umbau zu und Neubau von nachhaltigen, widerstandsfähigen und ressourceneffizienten
-    Gebäuden unter Verwendung lokaler Materialien bereitgestellt wird
-12.1.1:
-  title: Anzahl der Staaten mit nationalen Aktionsplänen zu nachhaltigem Konsum und
-    Produktion (SCP) oder SCP, die als Priorität oder Ziel in nationale Politik aufgenommen
-    wurden
-12.2.1:
-  title: Rohstoff-Fußabdruck, Rohstoff-Fußabdruck pro Kopf und Rohstoff-Fußabdruck
-    pro BIP
-12.2.2:
-  title:  Inländischer Materialverbrauch, inländischer Materialverbrauch pro Kopf und inländischer Materialverbrauch pro BIP
-12.3.1:
-  title: (a) Index der Lebensmittelverluste und (b) Index der Lebensmittelabfälle
-12.4.1:
-  title: Anzahl der Vertragsparteien internationaler multilateraler Umweltabkommen
-    über gefährliche Abfälle und andere Chemikalien, die ihren Bekenntnissen und Verpflichtungen
-    nachkommen, indem sie die gemäß dem jeweiligen Übereinkommen geforderten Informationen
-    übermitteln
-12.4.2:
-  title: Erzeugte gefährliche Abfälle pro Kopf und Anteil der behandelten gefährlichen
-    Abfälle, nach Art der Behandlung
-12.5.1:
-  title: Nationale Recyclingquote, Tonnen an recyceltem Material
-12.6.1:
-  title: Anzahl der Unternehmen, die Nachhaltigkeitsberichte veröffentlichen
-12.7.1:
-  title: Anzahl der Staaten, die nachhaltige öffentliche Beschaffungspolitik und Aktionspläne
-    umsetzen
-12.8.1:
-  title: 'Umfang, in dem (i) Bildung zu globaler Staatsbürgerschaft und (ii) Bildung
-    für nachhaltige Entwicklung, einschließlich der Geschlechtergleichstellung und
-    der Menschenrechte, auf allen Ebenen in: (a) nationale Bildungspolitik, (b) Lehrpläne,
-    (c) Lehrerausbildung und (d) Schulleistungsuntersuchung berücksichtigt werden'
-12.a.1:
-  title: Umfang der Unterstützung für Entwicklungsländer bei Forschung und Entwicklung
-    im Hinblick auf nachhaltigen Konsum und nachhaltige Produktion sowie umweltfreundliche
-    Technologien
-12.b.1:
-  title: Anzahl der Strategien oder Politiken für einen nachhaltigen Tourismus und
-    umgesetzte Aktionspläne mit vereinbarten Kontroll- und Bewertungsinstrumenten
-12.c.1:
-  title: Betrag der Subventionen für fossile Energieträger je Einheit BIP (Produktion
-    und Konsum) und als Anteil an den gesamten nationalen Ausgaben für fossile Energieträger
-13.1.1:
-  title: Anzahl der infolge von Katastrophen getöteten, vermissten und direkt betroffenen
-    Personen, je 100&nbsp;000 Einwohner
-13.1.2:
-  title: Anzahl der Staaten, die nationale Strategien zur Reduzierung des Katastrophenrisikos
-    in Einklang mit dem Sendai-Rahmenwerk zur Katastrophenvorsorge 2015-2030 verabschiedet
-    und umgesetzt haben
-13.1.3:
-  title: Anteil der lokalen Regierungen, die lokale Strategien zur Reduzierung des
-    Katastrophenrisikos in Einklang mit den nationalen Strategien zur Katastrophenvorsorge
-    verabschiedet und umgesetzt haben
-13.2.1:
-  title: Anzahl der Staaten, die die Ausarbeitung oder Umsetzung einer/s integrierten
-    Politik/Strategie/Plans verkündet haben, welche/r ihre Fähigkeit zur Anpassung
-    an die negativen Auswirkungen des Klimawandels erhöht und die Widerstandsfähigkeit
-    gegenüber Klimaänderungen als auch eine rückläufige Entwicklung der Treibhausgasemissionen
-    fördert ohne die Nahrungsmittelproduktion zu gefährden (einschließlich eines nationalen
-    Anpassungsplans, national festgelegten Beitrags, nationaler Kommunikation, zweijährlichen
-    Aktualisierungsberichts oder anderer)
-13.3.1:
-  title: Anzahl der Staaten, die die Minderung, Anpassung, Reduzierung der Auswirkungen
-    und Frühwarnsysteme in den primären, sekundären und tertiären Lehrplänen integriert
-    haben
-13.3.2:
-  title: Anzahl der Staaten, die die Stärkung des institutionellen, systemischen und
-    individuellen Kapazitätsaufbaus zur Umsetzung von Anpassung, Minderung und Technologietransfer
-    und Entwicklungsmaßnahmen verkündet haben
-13.a.1:
-  title: Mobilisierter Betrag an US-Dollar pro Jahr zwischen 2020 und 2025, anrechenbar
-    auf die Zusage von 100 Milliarden US-Dollar
-13.b.1:
-  title: Anzahl der am wenigsten entwickelten Länder und kleinen Inselentwicklungsstaaten,
-    die besondere Unterstützung erhalten und der Betrag der Unterstützung (Finanzmittel,
-    Technologie und capacity-building umfassend) für Mechanismen zum Aufbau von Kapazitäten
-    für eine wirksame klimawandelbezogene Planung und Verwaltung, mit Fokus auf Frauen,
-    Jugendliche und lokale und marginalisierte Gemeinschaften
-14.1.1:
-  title: Index der Eutrophierung der Küsten und Konzentration des schwimmenden Plastikmülls
-14.2.1:
-  title: Anteil der nationalen ausschließlichen Wirtschaftszonen, die mit ökosystembasierten
-    Ansätzen verwaltet werden
-14.3.1:
-  title: Durchschnittliche Versauerung der Meere (pH) gemessen an einer vereinbarten
-    Reihe von repräsentativen Probeentnahmestationen
-14.4.1:
-  title: Anteil der Fischbestände innerhalb des biologisch nachhaltigen Niveaus
-14.5.1:
-  title: Abdeckung von Meeresgebieten durch Schutzgebiete
-14.6.1:
-  title: Grad der Umsetzung internationaler Instrumente mit dem Ziel zur Bekämpfung illegaler, nicht gemeldeter und unregulierter Fischerei
-14.7.1:
-  title: Nachhaltige Fischerei als Anteil am BIP in kleinen Inselentwicklungsstaaten,
-    in den am wenigsten entwickelten Ländern und allen Ländern
-14.a.1:
-  title: Anteil am gesamten Forschungsbudget für Forschung im Bereich der Meerestechnik
-14.b.1:
-  title: Grad der Umsetzung von gesetzlichen/ regulatorischen/
-    politischen/ institutionellen Rahmenwerken, die Zugangsrechte für kleine Fischereien
-    anerkennen und schützen
-14.c.1:
-  title: Anzahl der Staaten, die durch rechtliche, politische und institutionelle
-    Rahmenbedingungen bei der Ratifizierung, Verabschiedung und Umsetzung meeresbezogener
-    Instrumentarien, die internationales Recht zum Schutz und zur nachhaltigen Nutzung
-    der Ozeane und ihrer Ressourcen (wie es dem Seerechtsübereinkommen der Vereinten
-    Nationen entspricht) umsetzen, Fortschritte machen
-15.1.1:
-  title: Waldfläche als Anteil an der gesamten Landfläche
-15.1.2:
-  title: Anteil der bedeutenden Gebiete für Biodiversität an Land und im Süßwasser,
-    die in Schutzgebieten liegen, nach Ökosystemtyp
-15.2.1:
-  title: Fortschritt bei der nachhaltigen Waldbewirtschaftung
-15.3.1:
-  title: Anteil der Fläche, die von Bodendegradation betroffenen ist, an der gesamten
-    Landfläche
-15.4.1:
-  title: Abdeckung der bedeutenden Gebiete für Biodiversität in den Bergen durch Schutzgebiete
-15.4.2:
-  title: Index der Grünbedeckung in den Bergen
-15.5.1:
-  title: Rote Liste Index
-15.6.1:
-  title: Anzahl der Staaten, die gesetzliche, administrative und politische Rahmenbedingungen
-    geschaffen haben, um Vorteile gerecht und gleichmäßig zu verteilen
-15.7.1:
-  title: Anteil der gehandelten Wildtiere, die gewildert oder geschmuggelt wurden
-15.8.1:
-  title: Anteil der Staaten, die relevante nationale Rechtsvorschriften verabschiedet
-    haben und Maßnahmen zur Vermeidung oder Bekämpfung von invasiven, gebietsfremden
-    Arten angemessen finanzieren
-15.9.1:
-  title: Fortschritte bei der Erreichung nationaler Ziele, die in Übereinstimmung
-    mit dem Aichi-Biodiversitätsziel 2 des Strategischen Plans zur Biodiversität 2011-2020
-    beschlossen wurden
-15.a.1:
-  title: Öffentliche Entwicklungszusammenarbeit (ODA) und öffentliche Ausgaben für den Erhalt
-    und die nachhaltige Nutzung der Biodiversität und der Ökosysteme
-15.b.1:
-  title: Öffentliche Entwicklungszusammenarbeit (ODA) und öffentliche Ausgaben für den Erhalt
-    und die nachhaltige Nutzung der Biodiversität und der Ökosysteme
-15.c.1:
-  title: Anteil der gehandelten Wildtiere, die gewildert oder geschmuggelt wurden
-16.1.1:
-  title: Anzahl der Opfer vorsätzlicher Tötung je 100&nbsp;000 Einwohner, nach Geschlecht
-    und Alter
-16.1.2:
-  title: Konfliktbedingte Todesfälle je 100&nbsp;000 Einwohner, nach Geschlecht, Alter
-    und Ursache
-16.1.3:
-  title: Anteil der Bevölkerung, die in den vergangenen 12&nbsp;Monaten (a) körperlicher
-    Gewalt, (b) psychischer Gewalt und (c) sexueller Gewalt ausgesetzt war
-16.1.4:
-  title: Anteil der Bevölkerung, die sich in ihrem Wohngebiet alleine sicher fühlt
-16.10.1:
-  title: Anzahl der bestätigten Fälle von Tötung, Entführung, erzwungenem Verschwinden,
-    willkürlicher Inhaftierung und Folter von Journalisten, zugehörigem Medienpersonal,
-    Gewerkschaftern und Menschenrechtsanwälten in den vergangenen 12&nbsp;Monaten
-16.10.2:
-  title: Anzahl der Staaten, die verfassungsrechtliche, gesetzliche und/oder politische
-    Garantieren für den öffentlichen Zugang zu Informationen verabschiedet und umgesetzt
-    haben
-16.2.1:
-  title: Anteil der Kinder im Alter von 1-17&nbsp;Jahren, die im vergangenen Monat eine
-    körperliche Strafe und/oder psychische Aggression durch Betreuungspersonen erfahren
-    haben
-16.2.2:
-  title: Anzahl der Opfer von Menschenhandel je 100&nbsp;000 Einwohner, nach Geschlecht,
-    Alter und Art der Ausbeutung
-16.2.3:
-  title: Anteil der jungen Frauen und Männer im Alter von 18-29&nbsp;Jahren, die bis zum
-    Alter von 18&nbsp;Jahren sexuelle Gewalt erlebt haben
-16.3.1:
-  title: Anteil der Opfer von Gewalttaten in den vergangenen 12&nbsp;Monaten, die ihre
-    Viktimisierung den zuständigen Behörden oder anderen offiziell anerkannten Stellen
-    der Konfliktaufarbeitung gemeldet haben
-16.3.2:
-  title: Nicht-verurteilte Gefangene als Anteil an der gesamten Gefangenenpopulation
-16.4.1:
-  title: Gesamtwert der ein- und ausgehenden illegalen Finanzströme (in aktuellen
-    US-Dollar)
-16.4.2:
-  title: Anteil der beschlagnahmten, aufgegriffenen oder abgegebenen Waffen, deren
-    illegale Herkunft oder Verwendung von einer zuständigen Behörde in Übereinstimmung
-    mit internationalen Methoden nachverfolgt oder festgestellt wurde
-16.5.1:
-  title: Anteil der Personen, die in den vergangenen 12&nbsp;Monaten mindestens einen Kontakt
-    zu einem öffentlichen Bediensteten hatten und diesem ein Bestechungsgeld gezahlt
-    haben oder von diesen um eine Bestechung gebeten wurden
-16.5.2:
-  title: Anteil der Unternehmen, die in den vergangenen 12&nbsp;Monaten mindestens einen
-    Kontakt mit einem öffentlichen Bediensteten hatten und diesem ein Bestechungsgeld
-    gezahlt haben oder von diesen um eine Bestechung gebeten wurden
-16.6.1:
-  title: Primärausgaben des Staates als Anteil am ursprünglich genehmigten Budget,
-    nach Sektor (oder nach Haushaltscodes oder Ähnlichem)
-16.6.2:
-  title: Anteil der Bevölkerung, die mit ihrer letzten Erfahrung mit öffentlichen
-    Dienstleistungen zufrieden war
-16.7.1:
-  title: Anteil der Stellen in nationalen und lokalen öffentlichen Institutionen einschließlich (a) der Gesetzgebung; (b) des öffentlichen Dienstes; und (c) der Judikativen, im Vergleich zu nationalen Verteilungen, nach Geschlecht, Alter, Menschen mit Behinderungen und Bevölkerungsgruppen
-16.7.2:
-  title: Anteil der Bevölkerung, die glaubt, dass die Entscheidungsfindung inklusiv
-    und bedarfsgesteuert ist, nach Geschlecht, Alter, Behinderung und Bevölkerungsgruppe
-16.8.1:
-  title: Anteil der Mitglieder und Stimmrechte von Entwicklungsländern in internationalen
-    Organisationen
-16.9.1:
-  title: Anteil der Kinder unter 5&nbsp;Jahre, deren Geburt von einer Zivilbehörde registriert
-    wurde, nach Alter
-16.a.1:
-  title: Existenz von unabhängigen nationalen Menschenrechtsinstitutionen in Übereinstimmung
-    mit den 'Pariser Grundsätzen'
-16.b.1:
-  title: Anteil der Bevölkerung, die angibt sich in den vergangenen 12 Monaten persönlich
-    auf Basis einer Diskriminierung, die nach internationalem Menschenrecht verboten
-    ist, diskriminiert oder belästigt gefühlt zu haben
-17.1.1:
-  title: Gesamte Staatseinnahmen als Anteil am BIP, nach Quelle
-17.1.2:
-  title: Anteil des Haushaltsbudgets, das durch inländische Steuern finanziert wird
-17.10.1:
-  title: Weltweit gewichtete durchschnittliche Einfuhrzollsätze
-17.11.1:
-  title: Anteil der Entwicklungsländer und der am wenigsten entwickelten Länder an
-    den weltweiten Exporten
-17.12.1:
-  title: Durchschnittliche Importzölle für Entwicklungsländer, am wenigsten entwickelte
-    Länder und kleine Inselentwicklungsländer
-17.13.1:
-  title: Makroökonomisches Dashboard
-17.14.1:
-  title: Anzahl der Staaten mit Mechanismen zur Verbesserung der Politikkohärenz bezogen
-    auf nachhaltige Entwicklung
-17.15.1:
-  title: Umfang der Nutzung ländereigener Ergebnisrahmenwerke und Planungsinstrumente
-    durch Geber von Entwicklungszusammenarbeit
-17.16.1:
-  title: Anzahl der Staaten, die Fortschritte bei der Kontrolle der Multi-Stakeholder-Entwicklungswirksamkeit,
-    die das Erreichen der Ziele für nachhaltige Entwicklung unterstützen, berichten
-17.17.1:
-  title: Betrag an US-Dollar, der für (a) öffentlich-private Partnerschaften und (b)
-    zivilgesellschaftliche Partnerschaften zugesagt wurde
-17.18.1:
-  title: Anteil der Nachhaltigkeitsindikatoren, die auf nationaler Ebene vollständig
-    - sofern gemäß dem Unterziel relevant - disaggregiert sind, in Übereinstimmung
-    mit den Grundprinzipien der amtlichen Statistik
-17.18.2:
-  title: Anzahl der Staaten mit einer nationalen statistischen Gesetzgebung im Einklang
-    mit den Grundprinzipien der amtlichen Statistik
-17.18.3:
-  title: Anzahl der Staaten mit einem nationalen statistischen Plan, der vollständig
-    finanziert ist und umgesetzt wird, nach Quelle der Finanzierung
-17.19.1:
-  title: Dollar-Wert aller zur Verfügung gestellten Ressourcen zur Stärkung der statistischen
-    Kapazität in Entwicklungsländern
-17.19.2:
-  title: Anteil der Staaten, die (a) in den letzten 10 Jahren mindestens eine Bevölkerungs-
-    und Wohnungszählung durchgeführt haben und (b) 100% bei der Geburtenregistrierung
-    sowie 80% bei der Registrierung der Sterbefälle erreicht haben
-17.2.1:
-  title: Öffentliche Nettoentwicklungsausgaben, insgesamt und an am wenigsten entwickelte
-    Länder, als Anteil am Bruttonationaleinkommen (BNE) der Geberländer des Ausschusses
-    für Entwicklungshilfe der Organisation für wirtschaftliche Zusammenarbeit und
-    Entwicklung (OECD)
-17.3.1:
-  title: Ausländische Direktinvestitionen, öffentliche Entwicklungszusammenarbeit (ODA)
-    und Süd-Süd-Kooperationen als Anteil am gesamten Haushaltsbudget
-17.3.2:
-  title: Volumen der (Rück-)Überweisungen (in US-Dollar) als Anteil am gesamten BIP
-17.4.1:
-  title: Schuldendienst als Anteil an Güter- und Dienstleistungsexporten
-17.5.1:
-  title: Anzahl der Staaten, die Investitionsförderprogramme für die am wenigsten
-    entwickelten Länder einführen und umsetzen
-17.6.1:
-  title: Anzahl der Vereinbarungen und Programme über Wissenschafts- und/oder Technologie-Kooperationen
-    zwischen Staaten, nach Art der Kooperation
-17.6.2:
-  title: Internet-Breitband-Verträge je 100 Einwohner, nach Geschwindigkeit
-17.7.1:
-  title: Gesamtbetrag der für Entwicklungsländer genehmigten Mittel zur Förderung
-    der Entwicklung, des Transfers, der öffentlichen Bereitstellung und der Verbreitung
-    umweltfreundlicher Technologien
-17.8.1:
-  title: Anteil der Einzelpersonen, die das Internet nutzen
-17.9.1:
-  title: Dollar-Wert der finanziellen und technischen Zusammenarbeit (einschließlich
-    durch Nord-Süd-, Süd-Süd- und Dreieckskooperationen) mit Entwicklungsländern
-2.1.1:
-  title: Prävalenz von Unterernährung
-2.1.2:
-  title: Prävalenz mittlerer oder schwerer Ernährungsunsicherheit in der Bevölkerung,
-    basierend auf der Erfahrungsskala für Ernährungsunsicherheit (FIES)
-2.2.1:
-  title: Prävalenz von Kleinwuchs (Körpergröße zum Alter <&nbsp;-2 Standardabweichung vom
-    Median des Wachstumsstandards für Kinder der Weltgesundheitsorganisation (WHO))
-    bei Kindern unter 5&nbsp;Jahren
-2.2.2:
-  title: Prävalenz von Fehlernährung (Gewicht zur Körpergröße >&nbsp;+2 oder <&nbsp;-2 Standardabweichung
-    vom Median des Wachstumsstandards für Kinder der WHO) bei Kindern unter 5&nbsp;Jahren,
-    nach der Art (Auszehrung und Übergewicht)
-2.3.1:
-  title: Produktionsvolumen je Arbeitskraft nach Unternehmensgrößenklassen der Betriebsgröße
-    in Land-/Weide-/Forstwirtschaft
-2.3.2:
-  title: Durchschnittliches Einkommen kleiner Nahrungsmittelproduzenten, nach Geschlecht
-    und indigenem Status
-2.4.1:
-  title: Anteil der landwirtschaftlichen Fläche unter produktiver und nachhaltiger
-    Bewirtschaftung
-2.5.1:
-  title: Anzahl der pflanzlichen und tierischen genetischen Ressourcen für Ernährung
-    und Landwirtschaft, die entweder in mittel- oder langfristigen Einrichtungen zu
-    deren Erhalt gesichert sind
-2.5.2:
-  title: Anteil der einheimischen Arten, die als gefährdet oder nicht gefährdet klassifiziert
-    sind oder deren Gefährdungsgrad unbekannt ist
-2.a.1:
-  title: Der 'Agriculture Orientation Index' für staatliche Ausgaben
-2.a.2:
-  title: Öffentliche Leistungen insgesamt (öffentliche Entwicklungszusammenarbeit (ODA) plus sonstige öffentliche Ausgaben) für den Landwirtschaftssektor
-2.b.1:
-  title: Ausfuhrsubventionen für landwirtschaftliche Güter
-2.b.2:
-  title: Ausfuhrsubventionen für landwirtschaftliche Güter
-2.c.1:
-  title: Indikator zu Schwankungen bei Lebensmittelpreisen
-3.1.1:
-  title: Müttersterblichkeitsrate
-3.1.2:
-  title: Anteil der Geburten unter der Aufsicht von qualifiziertem Gesundheitspersonal
-3.2.1:
-  title: Sterblichkeitsrate von Kindern unter 5&nbsp;Jahren
-3.2.2:
-  title: Sterblichkeitsrate von Neugeborenen
-3.3.1:
-  title: Anzahl der HIV-Neuinfektionen je 1&nbsp;000 nicht infizierter Einwohner, nach
-    Geschlecht, Alter und Risikogruppen
-3.3.2:
-  title: Tuberkulose-Inzidenz je 100&nbsp;000 Einwohner
-3.3.3:
-  title: Malaria-Inzidenz je 1&nbsp;000 Einwohner
-3.3.4:
-  title: Hepatitis-B-Inzidenz je 100&nbsp;000 Einwohner
-3.3.5:
-  title: Anzahl der Personen, die Maßnahmen gegen vernachlässigte Tropenkrankheiten
-    benötigen
-3.4.1:
-  title: Sterblichkeitsrate infolge von Herz-Kreislauf-Erkrankungen, Krebs, Diabetes
-    oder chronischen Atemwegserkrankungen
-3.4.2:
-  title: Sterblichkeitsrate bei Suizid
-3.5.1:
-  title: Abdeckung durch Behandlungsmaßnahmen (pharmakologische, psychosoziale und
-    Rehabilitations- und Nachsorgeleistungen) bei Substanzmissbrauch
-3.5.2:
-  title: Schädlicher Alkoholgebrauch, definiert gemäß den nationalen Gegebenheiten als
-    Alkoholkonsum pro Kopf (15&nbsp;Jahre und älter) innerhalb eines Kalenderjahres in
-    Litern reinem Alkohol
-3.6.1:
-  title: Sterblichkeitsrate aufgrund von Straßenverkehrsunfällen
-3.7.1:
-  title: Anteil der Frauen im gebärfähigen Alter (15-49&nbsp;Jahre), die ihren Anspruch
-    auf Familienplanung durch moderne Methoden umsetzen können
-3.7.2:
-  title: Geburtenrate bei Jugendlichen (10-14&nbsp;Jahre; 15-19&nbsp;Jahre) je 1&nbsp;000 Frauen derselben
-    Altersgruppe
-3.8.1:
-  title: Abdeckung der grundlegenden Gesundheitsleistungen (definiert als durchschnittliche
-    Abdeckung der grundlegenden Leistungen basierend auf Tracer-Interventionen, einschließlich
-    reproduktiver, Mütter-, Neugeborenen- und Kindergesundheit, infektiöser Krankheiten
-    und nicht übertragbarer Krankheiten sowie Kapazitäten und Zugang zu Serviceleistungen,
-    innerhalb der allgemein und der überwiegend benachteiligten Bevölkerung)
-3.8.2:
-  title: Anteil der Bevölkerung mit hohen Haushaltsausgaben für Gesundheit als Anteil
-    an den gesamten Haushaltsausgaben oder -einkommen
-3.9.1:
-  title: Sterblichkeitsrate infolge von Luftverschmutzung im Haushalt und der Umgebung
-3.9.2:
-  title: Sterblichkeitsrate infolge von Kontakt mit verunreinigtem Wasser, unzureichenden
-    sanitären Verhältnissen und mangelnder Hygiene (Kontakt mit unzureichenden "Wasser,
-    Sanitäreinrichtungen und Hygiene für alle"-Leistungen (WASH))
-3.9.3:
-  title: Sterblichkeit infolge unbeabsichtigter Vergiftung
-3.a.1:
-  title: Altersstandardisierte Prävalenz des aktuellen Tabakkonsums bei Personen im
-    Alter von 15&nbsp;Jahren und älter
-3.b.1:
-  title: Anteil der Zielbevölkerung, die alle Impfungen laut nationalem Programm
-    besitzt
-3.b.2:
-  title: Gesamte öffentliche Netto-Entwicklungszusammenarbeit (ODA) für medizinische Forschung
-    und grundlegende Gesundheitsversorgung
-3.b.3:
-  title: Anteil der Gesundheitseinrichtungen, die über einen Kernsatz relevanter und
-    wichtiger Medikamente verfügen, die nachhaltig verfügbar und bezahlbar sind
-3.c.1:
-  title: Dichte und Verteilung von medizinischem Fachpersonal
-3.d.1:
-  title: Kapazitäten für internationale Gesundheitsvorschriften (IGV) und Gesundheitsnotfallvorsorge
-4.1.1:
-  title: 'Anteil der Kinder und Jugendlichen, die (a) in Klasse 2/3; (b) am Ende der
-    Grundschule und (c) am Ende der Sekundarstufe I ein Mindestleistungsniveau in
-    (i) Lesen und (ii) Mathematik erreichen, nach Geschlecht'
-4.2.1:
-  title: Anteil der Kinder unter 5&nbsp;Jahren mit einer altersgemäßen  Entwicklung hinsichtlich
-    Gesundheit, Lernen und psycho-sozialem Wohlbefinden, nach Geschlecht
-4.2.2:
-  title: Teilnahmequote an frühkindlicher Bildung (ein Jahr vor dem offiziellen Einschulungsalter),
-    nach Geschlecht
-4.3.1:
-  title: Teilnahmequote von Jugendlichen und Erwachsenen an formaler und non-formaler
-    Bildung und Ausbildung in den vergangenen 12&nbsp;Monaten, nach Geschlecht
-4.4.1:
-  title: Anteil der Jugendlichen und Erwachsenen mit Kompetenzen in Informations-
-    und Kommunikationstechnologie (IKT), nach Art der Kompetenz
-4.5.1:
-  title: Paritäts-Indizes (weiblich/männlich, rural/urban, unterstes/oberstes Vermögensquantil
-    und sonstige, wie z. B. Grad der Behinderung, indigene Bevölkerung und konfliktbetroffen,
-    sobald Daten verfügbar werden) für alle Bildungsindikatoren dieser Liste, die
-    disaggregiert werden können
-4.6.1:
-  title: Anteil der Bevölkerung einer bestimmten Altersgruppe, die über ein festes
-    Mindestniveau an funktionalen (a) Lese- und (b) Rechenfähigkeiten verfügt, nach
-    Geschlecht
-4.7.1:
-  title: 'Umfang, in dem (i) Bildung zu globaler Staatsbürgerschaft und (ii) Bildung für nachhaltige Entwicklung, einschließlich der Geschlechtergleichstellung und der Menschenrechte, auf allen Ebenen in (a) nationale Bildungspolitik; (b) Lehrpläne; (c) Lehrerausbildung; und (d) Schulleistungsuntersuchung berücksichtigt werden '
-4.a.1:
-  title: 'Anteil der Schulen mit Zugang zu (a) Strom; (b) Internet für Unterrichtszwecke; (c) Computern für Unterrichtszwecke; (d) angepasste Infrastruktur und Materialien für Schüler mit Behinderungen; (e) Trinkwasser; (f) geschlechterspezifischen sanitären Anlagen; und g) grundlegende Ausstattung zum Händewaschen (gemäß den WASH-Indikator-Definitionen) '
-4.b.1:
-  title: Umfang der Ausgaben öffentlicher Entwicklungszusammenarbeit (ODA) für Stipendien
-    nach Sektor und Art des Studiums
-4.c.1:
-  title: 'Anteil der Lehrer in: (a) Vorschule (b) Grundschule (c ) Sekundarstufe I
-    und (d) Sekundarstufe II, die vor oder während ihrer Tätigkeit mindestens die
-    geforderte Grundausbildung (z. B. pädagogisches Training) zum Unterrichten für
-    die entsprechende Klassenstufe im jeweiligen Land erhalten haben'
-5.1.1:
-  title: Existenz gesetzlicher Rahmenbedingungen, die Gleichstellung und Nicht-Diskriminierung
-    aufgrund des Geschlechts fördern, durchsetzen und überwachen
-5.2.1:
-  title: Anteil der Frauen und Mädchen im Alter von 15&nbsp;Jahren und älter, die sich
-    in ihrer jetzigen oder früheren Partnerschaft physischer, sexueller oder psychischer
-    Gewalt durch ihren aktuellen oder früheren Intimpartner in den vergangenen 12
-    Monaten ausgesetzt waren, nach Art der Gewalt und Alter
-5.2.2:
-  title: Anteil der Frauen und Mädchen im Alter von 15&nbsp;Jahren und älter, die sexueller
-    Gewalt durch andere Personen als einen Intimpartner in den vergangenen 12&nbsp;Monaten
-    ausgesetzt waren, nach Alter und Ort des Geschehens
-5.3.1:
-  title: Anteil der 20- bis 24-jährigen Frauen, die vor einem Alter von 15 oder 18
-    Jahren verheiratet oder in einer vergleichbaren Verbindung waren
-5.3.2:
-  title: Anteil der Mädchen und Frauen im Alter von 15-49&nbsp;Jahren, die weiblicher Genitalverstümmelung
-    unterzogen wurden, nach Alter
-5.4.1:
-  title: Anteil des Zeitaufwands für unbezahlte Haus- und Pflegearbeit, nach Geschlecht,
-    Alter und Ort
-5.5.1:
-  title: Frauenanteil in (a) nationalen Parlamenten und (b) lokalen Regierungen
-5.5.2:
-  title: Frauenanteil an  Führungspositionen
-5.6.1:
-  title: Anteil der Frauen im Alter von 15-49 Jahren, die eigenständig fundierte Entscheidungen
-    über sexuelle Beziehungen, Verhütung und reproduktive Gesundheitsversorgung treffen
-5.6.2:
-  title: Anzahl der Staaten mit Gesetzen und Vorschriften, die einen uneingeschränkten
-    und gleichberechtigten Zugang für Frauen und Männer im Alter von 15 Jahren und
-    älter zu sexuellen und reproduktiven Gesundheitsleistungen, Information und Bildung
-    garantieren
-5.a.1:
-  title: (a) Anteil der gesamten landwirtschaftlichen Bevölkerung mit Eigentum oder sicheren Rechten an landwirtschaftlichen Flächen, nach Geschlecht; und (b) Anteil der Frauen an den Eigentümern oder Rechteinhabern landwirtschaftlicher Flächen, nach Art der Eigentumsverhältnisse
-5.a.2:
-  title: Anteil der Staaten, in denen der Rechtsrahmen (einschließlich Gewohnheitsrecht)
-    Frauen die gleichen Rechte auf Landeigentum und/oder -nutzung garantiert
-5.b.1:
-  title: Anteil der Personen, die ein Mobiltelefon besitzen, nach Geschlecht
-5.c.1:
-  title: Anteil der Staaten mit Systemen zur transparenten Verfolgung und Veröffentlichung
-    von Zuwendungen für Geschlechtergleichstellung und Stärkung der Rolle der Frau
-6.1.1:
-  title: Anteil der Bevölkerung mit Zugang zu einer sicheren Trinkwasserversorgung
-6.2.1:
-  title: Anteil der Bevölkerung mit (a) Zugang zu sicherer Sanitärversorgung und (b)
-    einem Handwaschbecken mit Seife und Wasser
-6.3.1:
-  title: Anteil des sicher behandelten Abwassers
-6.3.2:
-  title: Anteil der Gewässer mit guter Wasserqualität
-6.4.1:
-  title: Veränderung der Wassernutzungseffizienz im Zeitablauf
-6.4.2:
-  title: 'Grad der Wasserknappheit: Süßwasserentnahme als Anteil an den verfügbaren
-    Süßwasserressourcen'
-6.5.1:
-  title: Grad der Umsetzung eines integrierten Wasserressourcenmanagements (0-100)
-6.5.2:
-  title: Anteil der grenzüberschreitenden Flussgebiete mit einer operativen Vereinbarung
-    zur Wasserkooperation
-6.6.1:
-  title: Veränderung des Umfangs wasserbezogener Ökosysteme im Zeitablauf
-6.a.1:
-  title: Betrag der wasser- und sanitärbezogenen öffentlichen Entwicklungszusammenarbeit (ODA),
-    die Teil eines geregelten öffentlichen Haushaltsplans ist
-6.b.1:
-  title: Anteil der lokalen Verwaltungseinheiten mit etablierten und operativen Strategien
-    und Verfahren zur Beteiligung der Gemeinden am Wasser- und Abwassermanagement
-7.1.1:
-  title: Anteil der Bevölkerung mit Zugang zu Elektrizität
-7.1.2:
-  title: Anteil der Bevölkerung mit überwiegender Abhängigkeit von sauberen Energieträgern
-    und Technologien
-7.2.1:
-  title: Anteil der erneuerbaren Energien am gesamten Endenergieverbrauch
-7.3.1:
-  title: Energieintensität gemessen als Primärenergie zum BIP
-7.a.1:
-  title: Internationale Finanzströme an Entwicklungsländer zur Förderung von Forschung
-    und Entwicklung im Bereich sauberer Energien sowie erneuerbarer Energieproduktion,
-    einschließlich Hybridsystemen
-7.b.1:
-  title: Investitionen in Energieeffizienz als Anteil am BIP und der Betrag der ausländischen
-    Direktinvestitionen in Form von Finanzmitteln für Infrastruktur und Technologien
-    der Dienstleistungen für nachhaltige Entwicklung
-8.1.1:
-  title: Jährliche Wachstumsrate des realen BIP pro Kopf
-8.10.1:
-  title: (a) Anzahl der Bankfilialen je 100&nbsp;000 Erwachsener und (b) Anzahl der Geldautomaten
-    je 100&nbsp;000 Erwachsener
-8.10.2:
-  title: Anteil der Erwachsenen (15 Jahre und älter) mit einem Konto bei einer Bank
-    oder einem anderen Finanzinstitut oder einem mobilen Gelddienstleistungsanbieter
-8.2.1:
-  title: Jährliche Wachstumsrate des realen BIP je Beschäftigtem
-8.3.1:
-  title: Anteil der informellen Beschäftigung an allen Beschäftigungsverhältnissen
-    außerhalb der Landwirtschaft, nach Geschlecht
-8.4.1:
-  title: Rohstoff-Fußabdruck, Rohstoff-Fußabdruck pro Kopf und Rohstoff-Fußabdruck
-    pro BIP
-8.4.2:
-  title:  Inländischer Materialverbrauch, inländischer Materialverbrauch pro Kopf und inländischer Materialverbrauch pro BIP
-8.5.1:
-  title: Durchschnittlicher Stundenlohn von weiblichen und männlichen Beschäftigten,
-    nach Beruf, Alter und Menschen mit Behinderungen
-8.5.2:
-  title: Arbeitslosenquote, nach Geschlecht, Alter und Personen mit Behinderungen
-8.6.1:
-  title: Anteil der Jugendlichen (im Alter von 15-24&nbsp;Jahren), die nicht in schulischer
-    Ausbildung, in Beschäftigung oder Berufsaus- oder -weiterbildung sind
-8.7.1:
-  title: Anteil und Anzahl der Kinder im Alter von 5-17&nbsp;Jahren, die Kinderarbeit verrichten,
-    nach Geschlecht und Alter
-8.8.1:
-  title: Häufigkeitsraten von tödlichen und nicht-tödlichen Arbeitsunfällen, nach
-    Geschlecht und Migrationsstatus
-8.8.2:
-  title: Grad der nationalen Einhaltung der Arbeitnehmerrechte (Vereinigungsfreiheit
-    und Tarifverhandlungen) basierend auf Textquellen der Internationalen Arbeitsorganisation
-    (ILO) und nationaler Gesetzesgrundlagen, nach Geschlecht und Migrationsstatus
-8.9.1:
-  title: Direktes BIP des Tourismus als Anteil am gesamten BIP und als Wachstumsrate
-8.9.2:
-  title: Anteil der Arbeitsplätze im nachhaltigen Tourismus an den gesamten Arbeitsplätzen
-    im Tourismusbereich
-8.a.1:
-  title: Aid for Trade-Zusagen und -Auszahlungen
-8.b.1:
-  title: Existenz einer entwickelten und operationalisierten nationalen Strategie
-    zu Jugendbeschäftigung , als eigenständige Strategie oder als Teil einer nationalen
-    Beschäftigungsstrategie
-9.1.1:
-  title: Anteil der ländlichen Bevölkerung, die bis zu 2&nbsp;km entfernt von einer ganzjährig befahrbaren Straße lebt
-9.1.2:
-  title: Passagiere und Frachtvolumen, nach der Art des Transports
-9.2.1:
-  title: Wertschöpfung des Verarbeitenden Gewerbes als Anteil am BIP und pro Kopf
-9.2.2:
-  title: Beschäftigung im Verarbeitenden Gewerbe als Anteil an der Beschäftigung insgesamt
-9.3.1:
-  title: Anteil kleiner Unternehmen an der gesamten Wertschöpfung der Industrie
-9.3.2:
-  title: Anteil kleiner Unternehmen mit einem Kredit oder einem Kreditrahmen
-9.4.1:
-  title: CO<sub>2</sub>-Emissionen pro Wertschöpfungseinheit
-9.5.1:
-  title: Ausgaben für Forschung und Entwicklung als Anteil am BIP
-9.5.2:
-  title: Wissenschaftler (in Vollzeit-Äquivalenten) je eine Million Einwohner
-9.a.1:
-  title: Gesamte öffentliche internationale Unterstützung (öffentliche Entwicklungszusammenarbeit (ODA)
-    und sonstige öffentliche Ausgaben) für Infrastruktur
-9.b.1:
-  title: Anteil der Wertschöpfung der Medium- und High-Tech-Industrie an der Wertschöpfung
-    insgesamt
-9.c.1:
-  title: Anteil der Bevölkerung, die durch ein Mobilfunknetz abgedeckt ist, nach Technologie
+1.1.1-title: Anteil der Bevölkerung, die unter der internationalen Armutsgrenze lebt,
+  nach Geschlecht, Alter, Erwerbsstatus  und geographischer Lage (urban/rural)
+1.2.1-title: Anteil der Bevölkerung, die unter der nationalen Armutsgrenze lebt, nach
+  Geschlecht und Alter
+1.2.2-title: Anteil der Männer, Frauen und Kinder jeden Alters, die in Armut in all
+  ihren Dimensionen gemäß nationaler Definitionen leben
+1.3.1-title: Anteil der Bevölkerung, die durch soziale Sicherungssysteme abgesichert
+  ist, nach Geschlecht, untergliedert nach Kindern, Arbeitslosen, älteren Personen,
+  Menschen mit Behinderungen, Schwangeren, Neugeborenen, Opfern von Arbeitsunfällen
+  sowie Armen und Schwachen
+1.4.1-title: Anteil der Bevölkerung, die in Haushalten mit Zugang zur Grundversorgung
+  lebt
+1.4.2-title: Anteil der erwachsenen Gesamtbevölkerung mit gesicherter Verfügungsgewalt
+  über Grundeigentum, (a) mit gesetzlich anerkannter Dokumentation und (b) die ihr
+  Eigentumsrecht als sicher erachten, nach Geschlecht und Art der Eigentumsverhältnisse
+1.5.1-title: Anzahl der infolge von Katastrophen getöteten, vermissten und direkt
+  betroffenen Personen, je 100&nbsp;000 Einwohner
+1.5.2-title: Unmittelbarer wirtschaftlicher Schaden infolge von Katastrophen, im Verhältnis
+  zum globalen Bruttoinlandsprodukt (BIP)
+1.5.3-title: Anzahl der Staaten, die nationale Strategien zur Reduzierung des Katastrophenrisikos
+  in Einklang mit dem Sendai-Rahmenwerk zur Katastrophenvorsorge 2015-2030 verabschiedet
+  und umgesetzt haben
+1.5.4-title: Anteil der lokalen Regierungen, die lokale Strategien zur Reduzierung
+  des Katastrophenrisikos in Einklang mit den nationalen Strategien zur Katastrophenvorsorge
+  verabschiedet und umgesetzt haben
+1.a.1-title: Anteil der inländisch erwirtschafteten Ressourcen, die von der Regierung
+  direkt für Programme zur Armutsbekämpfung bereitgestellt werden
+1.a.2-title: Anteil der gesamten staatlichen Ausgaben für Grundleistungen (Bildung,
+  Gesundheit und soziale Sicherung)
+1.a.3-title: Summe der gesamten Zuschüsse und nicht schuldenwirksamen Zuflüsse, die
+  direkt Programmen zur Armutsbekämpfung zugewiesen werden, im Verhältnis zum BIP
+1.b.1-title: Anteil der wiederkehrenden staatlichen und Investitionsausgaben für Sektoren,
+  die überdurchschnittlich Frauen, Arme und benachteiligte Gruppen begünstigen
+10.1.1-title: Wachstumsraten der Haushaltsausgaben oder -einkommen pro Kopf der unteren
+  40&nbsp;Prozent der Bevölkerung und der Gesamtbevölkerung
+10.2.1-title: Anteil der Bevölkerung, die mit weniger als 50% des Medianeinkommens
+  leben, nach Geschlecht, Alter und Menschen mit Behinderungen
+10.3.1-title: Anteil der Bevölkerung, die angibt sich in den vergangenen 12&nbsp;Monaten
+  persönlich diskriminiert oder belästigt gefühlt zu haben basierend auf einem Diskriminierungsgrund,
+  der nach internationalem Menschenrechtsgesetzen verboten ist
+10.4.1-title: Anteil des Arbeitsnehmerentgelts am BIP, bestehend aus Löhnen, Gehältern
+  und Sozialversicherungsbeiträgen
+10.5.1-title: Financial Soundness Indicators
+10.6.1-title: Anteil der Mitglieder und Stimmrechte der Entwicklungsländer in internationalen
+  Organisationen
+10.7.1-title: Von Beschäftigten getragene Einstellungskosten als Anteil des monatlichen
+  Einkommens des Bestimmungslandes
+10.7.2-title: Anzahl der Staaten mit Migrationspolitik, die eine ordnungsgemäße sichere,
+  regelmäßige und verantwortungsbewusste Migration und Mobilität von Menschen ermöglicht
+10.a.1-title: Anteil der Zolltarife auf Einfuhren aus den am wenigsten entwickelten
+  Ländern sowie Entwicklungsländer mit Zollfreiheit
+10.b.1-title: Gesamte Finanzströme für Entwicklung, nach Nehmer- und Geberländern
+  und Art des Zahlungsstroms (z. B. öffentliche Entwicklungszusammenarbeit (ODA),
+  ausländische Direktinvestitionen und sonstige Finanzströme)
+10.c.1-title: Überweisungskosten  als Anteil am überwiesenen Betrag
+11.1.1-title: Anteil der urbanen Bevölkerung, die in Slums, informellen Siedlungen
+  oder unangemessenen Unterkünften lebt
+11.2.1-title: Anteil der Bevölkerung, die einen angemessenen Zugang zu öffentlichen
+  Verkehrsmitteln hat, nach Geschlecht, Alter und Menschen mit Behinderungen
+11.3.1-title: Verhältnis der Flächennutzungs- zur Bevölkerungswachstumsrate
+11.3.2-title: Anteil der Städte mit einer direkten Beteiligungsstruktur der Zivilgesellschaft
+  an der Stadtplanung und -verwaltung, die regelmäßig und demokratisch arbeitet
+11.4.1-title: Gesamtausgaben (öffentlich und privat) pro Kopf für die Bewahrung, den
+  Schutz und die Erhaltung des Kultur- und Naturerbes, nach Art des Erbes (Kultur,
+  Natur, gemischt und durch das Welterbezentrum ernannt), Regierungsebene (national,
+  regional und lokal/kommunal), Art der Ausgabe (Betriebsausgabe/Investition) und
+  Art der privaten Finanzierung (Sachspenden, privater gemeinnütziger Sektor und Förderer)
+11.5.1-title: Anzahl der infolge von Katastrophen getöteten, vermissten und direkt
+  betroffenen Personen, je 100&nbsp;000 Einwohner
+11.5.2-title: Unmittelbarer wirtschaftlicher Schaden im Verhältnis zum globalen BIP,
+  Schäden kritischer Infrastruktur und Anzahl der Ausfälle von Grundversorgungsleistungen
+  infolge von Katastrophen
+11.6.1-title: Anteil der Siedlungsabfälle, die regelmäßig gesammelt und ordnungsgemäß
+  entsorgt werden, an den insgesamt erzeugten Siedlungsabfällen, nach Städten
+11.6.2-title: Jahresmittelwerte für Feinstaub (z. B. PM2,5 und PM10) in Städten (bevölkerungsgewichtet)
+11.7.1-title: Durchschnittlicher Anteil der bebauten Fläche in Städten, die als Freifläche
+  öffentlich zugänglich ist, nach Geschlecht, Alter und Menschen mit Behinderungen
+11.7.2-title: Anteil der Personen, die in den vergangenen 12&nbsp;Monaten Opfer körperlicher
+  oder sexueller Belästigung wurden, nach Geschlecht, Alter, Behinderungsstatus und
+  Ort des Geschehens
+11.a.1-title: Anteil der Bevölkerung in Städten, die Stadt- und Regionalentwicklungspläne
+  unter Berücksichtigung der Bevölkerungsprognosen und des Ressourcenbedarfs umsetzen,
+  nach Größe der Stadt
+11.b.1-title: Anzahl der Staaten, die nationale Strategien zur Reduzierung des Katastrophenrisikos
+  in Einklang mit dem Sendai-Rahmenwerk zur Katastrophenvorsorge 2015-2030 verabschiedet
+  und umgesetzt haben
+11.b.2-title: Anteil der lokalen Regierungen, die lokale Strategien zur Reduzierung
+  des Katastrophenrisikos in Einklang mit den nationalen Strategien zur Katastrophenvorsorge
+  verabschiedet und umgesetzt haben
+11.c.1-title: Anteil der finanziellen Unterstützung, die den am wenigsten entwickelten
+  Ländern für den Umbau zu und Neubau von nachhaltigen, widerstandsfähigen und ressourceneffizienten
+  Gebäuden unter Verwendung lokaler Materialien bereitgestellt wird
+12.1.1-title: Anzahl der Staaten mit nationalen Aktionsplänen zu nachhaltigem Konsum
+  und Produktion (SCP) oder SCP, die als Priorität oder Ziel in nationale Politik
+  aufgenommen wurden
+12.2.1-title: Rohstoff-Fußabdruck, Rohstoff-Fußabdruck pro Kopf und Rohstoff-Fußabdruck
+  pro BIP
+12.2.2-title: Inländischer Materialverbrauch, inländischer Materialverbrauch pro Kopf
+  und inländischer Materialverbrauch pro BIP
+12.3.1-title: (a) Index der Lebensmittelverluste und (b) Index der Lebensmittelabfälle
+12.4.1-title: Anzahl der Vertragsparteien internationaler multilateraler Umweltabkommen
+  über gefährliche Abfälle und andere Chemikalien, die ihren Bekenntnissen und Verpflichtungen
+  nachkommen, indem sie die gemäß dem jeweiligen Übereinkommen geforderten Informationen
+  übermitteln
+12.4.2-title: Erzeugte gefährliche Abfälle pro Kopf und Anteil der behandelten gefährlichen
+  Abfälle, nach Art der Behandlung
+12.5.1-title: Nationale Recyclingquote, Tonnen an recyceltem Material
+12.6.1-title: Anzahl der Unternehmen, die Nachhaltigkeitsberichte veröffentlichen
+12.7.1-title: Anzahl der Staaten, die nachhaltige öffentliche Beschaffungspolitik
+  und Aktionspläne umsetzen
+12.8.1-title: 'Umfang, in dem (i) Bildung zu globaler Staatsbürgerschaft und (ii)
+  Bildung für nachhaltige Entwicklung, einschließlich der Geschlechtergleichstellung
+  und der Menschenrechte, auf allen Ebenen in: (a) nationale Bildungspolitik, (b)
+  Lehrpläne, (c) Lehrerausbildung und (d) Schulleistungsuntersuchung berücksichtigt
+  werden'
+12.a.1-title: Umfang der Unterstützung für Entwicklungsländer bei Forschung und Entwicklung
+  im Hinblick auf nachhaltigen Konsum und nachhaltige Produktion sowie umweltfreundliche
+  Technologien
+12.b.1-title: Anzahl der Strategien oder Politiken für einen nachhaltigen Tourismus
+  und umgesetzte Aktionspläne mit vereinbarten Kontroll- und Bewertungsinstrumenten
+12.c.1-title: Betrag der Subventionen für fossile Energieträger je Einheit BIP (Produktion
+  und Konsum) und als Anteil an den gesamten nationalen Ausgaben für fossile Energieträger
+13.1.1-title: Anzahl der infolge von Katastrophen getöteten, vermissten und direkt
+  betroffenen Personen, je 100&nbsp;000 Einwohner
+13.1.2-title: Anzahl der Staaten, die nationale Strategien zur Reduzierung des Katastrophenrisikos
+  in Einklang mit dem Sendai-Rahmenwerk zur Katastrophenvorsorge 2015-2030 verabschiedet
+  und umgesetzt haben
+13.1.3-title: Anteil der lokalen Regierungen, die lokale Strategien zur Reduzierung
+  des Katastrophenrisikos in Einklang mit den nationalen Strategien zur Katastrophenvorsorge
+  verabschiedet und umgesetzt haben
+13.2.1-title: Anzahl der Staaten, die die Ausarbeitung oder Umsetzung einer/s integrierten
+  Politik/Strategie/Plans verkündet haben, welche/r ihre Fähigkeit zur Anpassung an
+  die negativen Auswirkungen des Klimawandels erhöht und die Widerstandsfähigkeit
+  gegenüber Klimaänderungen als auch eine rückläufige Entwicklung der Treibhausgasemissionen
+  fördert ohne die Nahrungsmittelproduktion zu gefährden (einschließlich eines nationalen
+  Anpassungsplans, national festgelegten Beitrags, nationaler Kommunikation, zweijährlichen
+  Aktualisierungsberichts oder anderer)
+13.3.1-title: Anzahl der Staaten, die die Minderung, Anpassung, Reduzierung der Auswirkungen
+  und Frühwarnsysteme in den primären, sekundären und tertiären Lehrplänen integriert
+  haben
+13.3.2-title: Anzahl der Staaten, die die Stärkung des institutionellen, systemischen
+  und individuellen Kapazitätsaufbaus zur Umsetzung von Anpassung, Minderung und Technologietransfer
+  und Entwicklungsmaßnahmen verkündet haben
+13.a.1-title: Mobilisierter Betrag an US-Dollar pro Jahr zwischen 2020 und 2025, anrechenbar
+  auf die Zusage von 100 Milliarden US-Dollar
+13.b.1-title: Anzahl der am wenigsten entwickelten Länder und kleinen Inselentwicklungsstaaten,
+  die besondere Unterstützung erhalten und der Betrag der Unterstützung (Finanzmittel,
+  Technologie und capacity-building umfassend) für Mechanismen zum Aufbau von Kapazitäten
+  für eine wirksame klimawandelbezogene Planung und Verwaltung, mit Fokus auf Frauen,
+  Jugendliche und lokale und marginalisierte Gemeinschaften
+14.1.1-title: Index der Eutrophierung der Küsten und Konzentration des schwimmenden
+  Plastikmülls
+14.2.1-title: Anteil der nationalen ausschließlichen Wirtschaftszonen, die mit ökosystembasierten
+  Ansätzen verwaltet werden
+14.3.1-title: Durchschnittliche Versauerung der Meere (pH) gemessen an einer vereinbarten
+  Reihe von repräsentativen Probeentnahmestationen
+14.4.1-title: Anteil der Fischbestände innerhalb des biologisch nachhaltigen Niveaus
+14.5.1-title: Abdeckung von Meeresgebieten durch Schutzgebiete
+14.6.1-title: Grad der Umsetzung internationaler Instrumente mit dem Ziel zur Bekämpfung
+  illegaler, nicht gemeldeter und unregulierter Fischerei
+14.7.1-title: Nachhaltige Fischerei als Anteil am BIP in kleinen Inselentwicklungsstaaten,
+  in den am wenigsten entwickelten Ländern und allen Ländern
+14.a.1-title: Anteil am gesamten Forschungsbudget für Forschung im Bereich der Meerestechnik
+14.b.1-title: Grad der Umsetzung von gesetzlichen/ regulatorischen/ politischen/ institutionellen
+  Rahmenwerken, die Zugangsrechte für kleine Fischereien anerkennen und schützen
+14.c.1-title: Anzahl der Staaten, die durch rechtliche, politische und institutionelle
+  Rahmenbedingungen bei der Ratifizierung, Verabschiedung und Umsetzung meeresbezogener
+  Instrumentarien, die internationales Recht zum Schutz und zur nachhaltigen Nutzung
+  der Ozeane und ihrer Ressourcen (wie es dem Seerechtsübereinkommen der Vereinten
+  Nationen entspricht) umsetzen, Fortschritte machen
+15.1.1-title: Waldfläche als Anteil an der gesamten Landfläche
+15.1.2-title: Anteil der bedeutenden Gebiete für Biodiversität an Land und im Süßwasser,
+  die in Schutzgebieten liegen, nach Ökosystemtyp
+15.2.1-title: Fortschritt bei der nachhaltigen Waldbewirtschaftung
+15.3.1-title: Anteil der Fläche, die von Bodendegradation betroffenen ist, an der
+  gesamten Landfläche
+15.4.1-title: Abdeckung der bedeutenden Gebiete für Biodiversität in den Bergen durch
+  Schutzgebiete
+15.4.2-title: Index der Grünbedeckung in den Bergen
+15.5.1-title: Rote Liste Index
+15.6.1-title: Anzahl der Staaten, die gesetzliche, administrative und politische Rahmenbedingungen
+  geschaffen haben, um Vorteile gerecht und gleichmäßig zu verteilen
+15.7.1-title: Anteil der gehandelten Wildtiere, die gewildert oder geschmuggelt wurden
+15.8.1-title: Anteil der Staaten, die relevante nationale Rechtsvorschriften verabschiedet
+  haben und Maßnahmen zur Vermeidung oder Bekämpfung von invasiven, gebietsfremden
+  Arten angemessen finanzieren
+15.9.1-title: Fortschritte bei der Erreichung nationaler Ziele, die in Übereinstimmung
+  mit dem Aichi-Biodiversitätsziel 2 des Strategischen Plans zur Biodiversität 2011-2020
+  beschlossen wurden
+15.a.1-title: Öffentliche Entwicklungszusammenarbeit (ODA) und öffentliche Ausgaben
+  für den Erhalt und die nachhaltige Nutzung der Biodiversität und der Ökosysteme
+15.b.1-title: Öffentliche Entwicklungszusammenarbeit (ODA) und öffentliche Ausgaben
+  für den Erhalt und die nachhaltige Nutzung der Biodiversität und der Ökosysteme
+15.c.1-title: Anteil der gehandelten Wildtiere, die gewildert oder geschmuggelt wurden
+16.1.1-title: Anzahl der Opfer vorsätzlicher Tötung je 100&nbsp;000 Einwohner, nach
+  Geschlecht und Alter
+16.1.2-title: Konfliktbedingte Todesfälle je 100&nbsp;000 Einwohner, nach Geschlecht,
+  Alter und Ursache
+16.1.3-title: Anteil der Bevölkerung, die in den vergangenen 12&nbsp;Monaten (a) körperlicher
+  Gewalt, (b) psychischer Gewalt und (c) sexueller Gewalt ausgesetzt war
+16.1.4-title: Anteil der Bevölkerung, die sich in ihrem Wohngebiet alleine sicher
+  fühlt
+16.10.1-title: Anzahl der bestätigten Fälle von Tötung, Entführung, erzwungenem Verschwinden,
+  willkürlicher Inhaftierung und Folter von Journalisten, zugehörigem Medienpersonal,
+  Gewerkschaftern und Menschenrechtsanwälten in den vergangenen 12&nbsp;Monaten
+16.10.2-title: Anzahl der Staaten, die verfassungsrechtliche, gesetzliche und/oder
+  politische Garantieren für den öffentlichen Zugang zu Informationen verabschiedet
+  und umgesetzt haben
+16.2.1-title: Anteil der Kinder im Alter von 1-17&nbsp;Jahren, die im vergangenen
+  Monat eine körperliche Strafe und/oder psychische Aggression durch Betreuungspersonen
+  erfahren haben
+16.2.2-title: Anzahl der Opfer von Menschenhandel je 100&nbsp;000 Einwohner, nach
+  Geschlecht, Alter und Art der Ausbeutung
+16.2.3-title: Anteil der jungen Frauen und Männer im Alter von 18-29&nbsp;Jahren,
+  die bis zum Alter von 18&nbsp;Jahren sexuelle Gewalt erlebt haben
+16.3.1-title: Anteil der Opfer von Gewalttaten in den vergangenen 12&nbsp;Monaten,
+  die ihre Viktimisierung den zuständigen Behörden oder anderen offiziell anerkannten
+  Stellen der Konfliktaufarbeitung gemeldet haben
+16.3.2-title: Nicht-verurteilte Gefangene als Anteil an der gesamten Gefangenenpopulation
+16.4.1-title: Gesamtwert der ein- und ausgehenden illegalen Finanzströme (in aktuellen
+  US-Dollar)
+16.4.2-title: Anteil der beschlagnahmten, aufgegriffenen oder abgegebenen Waffen,
+  deren illegale Herkunft oder Verwendung von einer zuständigen Behörde in Übereinstimmung
+  mit internationalen Methoden nachverfolgt oder festgestellt wurde
+16.5.1-title: Anteil der Personen, die in den vergangenen 12&nbsp;Monaten mindestens
+  einen Kontakt zu einem öffentlichen Bediensteten hatten und diesem ein Bestechungsgeld
+  gezahlt haben oder von diesen um eine Bestechung gebeten wurden
+16.5.2-title: Anteil der Unternehmen, die in den vergangenen 12&nbsp;Monaten mindestens
+  einen Kontakt mit einem öffentlichen Bediensteten hatten und diesem ein Bestechungsgeld
+  gezahlt haben oder von diesen um eine Bestechung gebeten wurden
+16.6.1-title: Primärausgaben des Staates als Anteil am ursprünglich genehmigten Budget,
+  nach Sektor (oder nach Haushaltscodes oder Ähnlichem)
+16.6.2-title: Anteil der Bevölkerung, die mit ihrer letzten Erfahrung mit öffentlichen
+  Dienstleistungen zufrieden war
+16.7.1-title: Anteil der Stellen in nationalen und lokalen öffentlichen Institutionen
+  einschließlich (a) der Gesetzgebung; (b) des öffentlichen Dienstes; und (c) der
+  Judikativen, im Vergleich zu nationalen Verteilungen, nach Geschlecht, Alter, Menschen
+  mit Behinderungen und Bevölkerungsgruppen
+16.7.2-title: Anteil der Bevölkerung, die glaubt, dass die Entscheidungsfindung inklusiv
+  und bedarfsgesteuert ist, nach Geschlecht, Alter, Behinderung und Bevölkerungsgruppe
+16.8.1-title: Anteil der Mitglieder und Stimmrechte von Entwicklungsländern in internationalen
+  Organisationen
+16.9.1-title: Anteil der Kinder unter 5&nbsp;Jahre, deren Geburt von einer Zivilbehörde
+  registriert wurde, nach Alter
+16.a.1-title: Existenz von unabhängigen nationalen Menschenrechtsinstitutionen in
+  Übereinstimmung mit den 'Pariser Grundsätzen'
+16.b.1-title: Anteil der Bevölkerung, die angibt sich in den vergangenen 12 Monaten
+  persönlich auf Basis einer Diskriminierung, die nach internationalem Menschenrecht
+  verboten ist, diskriminiert oder belästigt gefühlt zu haben
+17.1.1-title: Gesamte Staatseinnahmen als Anteil am BIP, nach Quelle
+17.1.2-title: Anteil des Haushaltsbudgets, das durch inländische Steuern finanziert
+  wird
+17.10.1-title: Weltweit gewichtete durchschnittliche Einfuhrzollsätze
+17.11.1-title: Anteil der Entwicklungsländer und der am wenigsten entwickelten Länder
+  an den weltweiten Exporten
+17.12.1-title: Durchschnittliche Importzölle für Entwicklungsländer, am wenigsten
+  entwickelte Länder und kleine Inselentwicklungsländer
+17.13.1-title: Makroökonomisches Dashboard
+17.14.1-title: Anzahl der Staaten mit Mechanismen zur Verbesserung der Politikkohärenz
+  bezogen auf nachhaltige Entwicklung
+17.15.1-title: Umfang der Nutzung ländereigener Ergebnisrahmenwerke und Planungsinstrumente
+  durch Geber von Entwicklungszusammenarbeit
+17.16.1-title: Anzahl der Staaten, die Fortschritte bei der Kontrolle der Multi-Stakeholder-Entwicklungswirksamkeit,
+  die das Erreichen der Ziele für nachhaltige Entwicklung unterstützen, berichten
+17.17.1-title: Betrag an US-Dollar, der für (a) öffentlich-private Partnerschaften
+  und (b) zivilgesellschaftliche Partnerschaften zugesagt wurde
+17.18.1-title: Anteil der Nachhaltigkeitsindikatoren, die auf nationaler Ebene vollständig
+  - sofern gemäß dem Unterziel relevant - disaggregiert sind, in Übereinstimmung mit
+  den Grundprinzipien der amtlichen Statistik
+17.18.2-title: Anzahl der Staaten mit einer nationalen statistischen Gesetzgebung
+  im Einklang mit den Grundprinzipien der amtlichen Statistik
+17.18.3-title: Anzahl der Staaten mit einem nationalen statistischen Plan, der vollständig
+  finanziert ist und umgesetzt wird, nach Quelle der Finanzierung
+17.19.1-title: Dollar-Wert aller zur Verfügung gestellten Ressourcen zur Stärkung
+  der statistischen Kapazität in Entwicklungsländern
+17.19.2-title: Anteil der Staaten, die (a) in den letzten 10 Jahren mindestens eine
+  Bevölkerungs- und Wohnungszählung durchgeführt haben und (b) 100% bei der Geburtenregistrierung
+  sowie 80% bei der Registrierung der Sterbefälle erreicht haben
+17.2.1-title: Öffentliche Nettoentwicklungsausgaben, insgesamt und an am wenigsten
+  entwickelte Länder, als Anteil am Bruttonationaleinkommen (BNE) der Geberländer
+  des Ausschusses für Entwicklungshilfe der Organisation für wirtschaftliche Zusammenarbeit
+  und Entwicklung (OECD)
+17.3.1-title: Ausländische Direktinvestitionen, öffentliche Entwicklungszusammenarbeit
+  (ODA) und Süd-Süd-Kooperationen als Anteil am gesamten Haushaltsbudget
+17.3.2-title: Volumen der (Rück-)Überweisungen (in US-Dollar) als Anteil am gesamten
+  BIP
+17.4.1-title: Schuldendienst als Anteil an Güter- und Dienstleistungsexporten
+17.5.1-title: Anzahl der Staaten, die Investitionsförderprogramme für die am wenigsten
+  entwickelten Länder einführen und umsetzen
+17.6.1-title: Anzahl der Vereinbarungen und Programme über Wissenschafts- und/oder
+  Technologie-Kooperationen zwischen Staaten, nach Art der Kooperation
+17.6.2-title: Internet-Breitband-Verträge je 100 Einwohner, nach Geschwindigkeit
+17.7.1-title: Gesamtbetrag der für Entwicklungsländer genehmigten Mittel zur Förderung
+  der Entwicklung, des Transfers, der öffentlichen Bereitstellung und der Verbreitung
+  umweltfreundlicher Technologien
+17.8.1-title: Anteil der Einzelpersonen, die das Internet nutzen
+17.9.1-title: Dollar-Wert der finanziellen und technischen Zusammenarbeit (einschließlich
+  durch Nord-Süd-, Süd-Süd- und Dreieckskooperationen) mit Entwicklungsländern
+2.1.1-title: Prävalenz von Unterernährung
+2.1.2-title: Prävalenz mittlerer oder schwerer Ernährungsunsicherheit in der Bevölkerung,
+  basierend auf der Erfahrungsskala für Ernährungsunsicherheit (FIES)
+2.2.1-title: Prävalenz von Kleinwuchs (Körpergröße zum Alter <&nbsp;-2 Standardabweichung
+  vom Median des Wachstumsstandards für Kinder der Weltgesundheitsorganisation (WHO))
+  bei Kindern unter 5&nbsp;Jahren
+2.2.2-title: Prävalenz von Fehlernährung (Gewicht zur Körpergröße >&nbsp;+2 oder <&nbsp;-2
+  Standardabweichung vom Median des Wachstumsstandards für Kinder der WHO) bei Kindern
+  unter 5&nbsp;Jahren, nach der Art (Auszehrung und Übergewicht)
+2.3.1-title: Produktionsvolumen je Arbeitskraft nach Unternehmensgrößenklassen der
+  Betriebsgröße in Land-/Weide-/Forstwirtschaft
+2.3.2-title: Durchschnittliches Einkommen kleiner Nahrungsmittelproduzenten, nach
+  Geschlecht und indigenem Status
+2.4.1-title: Anteil der landwirtschaftlichen Fläche unter produktiver und nachhaltiger
+  Bewirtschaftung
+2.5.1-title: Anzahl der pflanzlichen und tierischen genetischen Ressourcen für Ernährung
+  und Landwirtschaft, die entweder in mittel- oder langfristigen Einrichtungen zu
+  deren Erhalt gesichert sind
+2.5.2-title: Anteil der einheimischen Arten, die als gefährdet oder nicht gefährdet
+  klassifiziert sind oder deren Gefährdungsgrad unbekannt ist
+2.a.1-title: Der 'Agriculture Orientation Index' für staatliche Ausgaben
+2.a.2-title: Öffentliche Leistungen insgesamt (öffentliche Entwicklungszusammenarbeit
+  (ODA) plus sonstige öffentliche Ausgaben) für den Landwirtschaftssektor
+2.b.1-title: Ausfuhrsubventionen für landwirtschaftliche Güter
+2.b.2-title: Ausfuhrsubventionen für landwirtschaftliche Güter
+2.c.1-title: Indikator zu Schwankungen bei Lebensmittelpreisen
+3.1.1-title: Müttersterblichkeitsrate
+3.1.2-title: Anteil der Geburten unter der Aufsicht von qualifiziertem Gesundheitspersonal
+3.2.1-title: Sterblichkeitsrate von Kindern unter 5&nbsp;Jahren
+3.2.2-title: Sterblichkeitsrate von Neugeborenen
+3.3.1-title: Anzahl der HIV-Neuinfektionen je 1&nbsp;000 nicht infizierter Einwohner,
+  nach Geschlecht, Alter und Risikogruppen
+3.3.2-title: Tuberkulose-Inzidenz je 100&nbsp;000 Einwohner
+3.3.3-title: Malaria-Inzidenz je 1&nbsp;000 Einwohner
+3.3.4-title: Hepatitis-B-Inzidenz je 100&nbsp;000 Einwohner
+3.3.5-title: Anzahl der Personen, die Maßnahmen gegen vernachlässigte Tropenkrankheiten
+  benötigen
+3.4.1-title: Sterblichkeitsrate infolge von Herz-Kreislauf-Erkrankungen, Krebs, Diabetes
+  oder chronischen Atemwegserkrankungen
+3.4.2-title: Sterblichkeitsrate bei Suizid
+3.5.1-title: Abdeckung durch Behandlungsmaßnahmen (pharmakologische, psychosoziale
+  und Rehabilitations- und Nachsorgeleistungen) bei Substanzmissbrauch
+3.5.2-title: Schädlicher Alkoholgebrauch, definiert gemäß den nationalen Gegebenheiten
+  als Alkoholkonsum pro Kopf (15&nbsp;Jahre und älter) innerhalb eines Kalenderjahres
+  in Litern reinem Alkohol
+3.6.1-title: Sterblichkeitsrate aufgrund von Straßenverkehrsunfällen
+3.7.1-title: Anteil der Frauen im gebärfähigen Alter (15-49&nbsp;Jahre), die ihren
+  Anspruch auf Familienplanung durch moderne Methoden umsetzen können
+3.7.2-title: Geburtenrate bei Jugendlichen (10-14&nbsp;Jahre; 15-19&nbsp;Jahre) je
+  1&nbsp;000 Frauen derselben Altersgruppe
+3.8.1-title: Abdeckung der grundlegenden Gesundheitsleistungen (definiert als durchschnittliche
+  Abdeckung der grundlegenden Leistungen basierend auf Tracer-Interventionen, einschließlich
+  reproduktiver, Mütter-, Neugeborenen- und Kindergesundheit, infektiöser Krankheiten
+  und nicht übertragbarer Krankheiten sowie Kapazitäten und Zugang zu Serviceleistungen,
+  innerhalb der allgemein und der überwiegend benachteiligten Bevölkerung)
+3.8.2-title: Anteil der Bevölkerung mit hohen Haushaltsausgaben für Gesundheit als
+  Anteil an den gesamten Haushaltsausgaben oder -einkommen
+3.9.1-title: Sterblichkeitsrate infolge von Luftverschmutzung im Haushalt und der
+  Umgebung
+3.9.2-title: Sterblichkeitsrate infolge von Kontakt mit verunreinigtem Wasser, unzureichenden
+  sanitären Verhältnissen und mangelnder Hygiene (Kontakt mit unzureichenden "Wasser,
+  Sanitäreinrichtungen und Hygiene für alle"-Leistungen (WASH))
+3.9.3-title: Sterblichkeit infolge unbeabsichtigter Vergiftung
+3.a.1-title: Altersstandardisierte Prävalenz des aktuellen Tabakkonsums bei Personen
+  im Alter von 15&nbsp;Jahren und älter
+3.b.1-title: Anteil der Zielbevölkerung, die alle Impfungen laut nationalem Programm
+  besitzt
+3.b.2-title: Gesamte öffentliche Netto-Entwicklungszusammenarbeit (ODA) für medizinische
+  Forschung und grundlegende Gesundheitsversorgung
+3.b.3-title: Anteil der Gesundheitseinrichtungen, die über einen Kernsatz relevanter
+  und wichtiger Medikamente verfügen, die nachhaltig verfügbar und bezahlbar sind
+3.c.1-title: Dichte und Verteilung von medizinischem Fachpersonal
+3.d.1-title: Kapazitäten für internationale Gesundheitsvorschriften (IGV) und Gesundheitsnotfallvorsorge
+4.1.1-title: Anteil der Kinder und Jugendlichen, die (a) in Klasse 2/3; (b) am Ende
+  der Grundschule und (c) am Ende der Sekundarstufe I ein Mindestleistungsniveau in
+  (i) Lesen und (ii) Mathematik erreichen, nach Geschlecht
+4.2.1-title: Anteil der Kinder unter 5&nbsp;Jahren mit einer altersgemäßen  Entwicklung
+  hinsichtlich Gesundheit, Lernen und psycho-sozialem Wohlbefinden, nach Geschlecht
+4.2.2-title: Teilnahmequote an frühkindlicher Bildung (ein Jahr vor dem offiziellen
+  Einschulungsalter), nach Geschlecht
+4.3.1-title: Teilnahmequote von Jugendlichen und Erwachsenen an formaler und non-formaler
+  Bildung und Ausbildung in den vergangenen 12&nbsp;Monaten, nach Geschlecht
+4.4.1-title: Anteil der Jugendlichen und Erwachsenen mit Kompetenzen in Informations-
+  und Kommunikationstechnologie (IKT), nach Art der Kompetenz
+4.5.1-title: Paritäts-Indizes (weiblich/männlich, rural/urban, unterstes/oberstes
+  Vermögensquantil und sonstige, wie z. B. Grad der Behinderung, indigene Bevölkerung
+  und konfliktbetroffen, sobald Daten verfügbar werden) für alle Bildungsindikatoren
+  dieser Liste, die disaggregiert werden können
+4.6.1-title: Anteil der Bevölkerung einer bestimmten Altersgruppe, die über ein festes
+  Mindestniveau an funktionalen (a) Lese- und (b) Rechenfähigkeiten verfügt, nach
+  Geschlecht
+4.7.1-title: 'Umfang, in dem (i) Bildung zu globaler Staatsbürgerschaft und (ii) Bildung
+  für nachhaltige Entwicklung, einschließlich der Geschlechtergleichstellung und der
+  Menschenrechte, auf allen Ebenen in (a) nationale Bildungspolitik; (b) Lehrpläne;
+  (c) Lehrerausbildung; und (d) Schulleistungsuntersuchung berücksichtigt werden '
+4.a.1-title: 'Anteil der Schulen mit Zugang zu (a) Strom; (b) Internet für Unterrichtszwecke;
+  (c) Computern für Unterrichtszwecke; (d) angepasste Infrastruktur und Materialien
+  für Schüler mit Behinderungen; (e) Trinkwasser; (f) geschlechterspezifischen sanitären
+  Anlagen; und g) grundlegende Ausstattung zum Händewaschen (gemäß den WASH-Indikator-Definitionen) '
+4.b.1-title: Umfang der Ausgaben öffentlicher Entwicklungszusammenarbeit (ODA) für
+  Stipendien nach Sektor und Art des Studiums
+4.c.1-title: 'Anteil der Lehrer in: (a) Vorschule (b) Grundschule (c ) Sekundarstufe
+  I und (d) Sekundarstufe II, die vor oder während ihrer Tätigkeit mindestens die
+  geforderte Grundausbildung (z. B. pädagogisches Training) zum Unterrichten für die
+  entsprechende Klassenstufe im jeweiligen Land erhalten haben'
+5.1.1-title: Existenz gesetzlicher Rahmenbedingungen, die Gleichstellung und Nicht-Diskriminierung
+  aufgrund des Geschlechts fördern, durchsetzen und überwachen
+5.2.1-title: Anteil der Frauen und Mädchen im Alter von 15&nbsp;Jahren und älter,
+  die sich in ihrer jetzigen oder früheren Partnerschaft physischer, sexueller oder
+  psychischer Gewalt durch ihren aktuellen oder früheren Intimpartner in den vergangenen
+  12 Monaten ausgesetzt waren, nach Art der Gewalt und Alter
+5.2.2-title: Anteil der Frauen und Mädchen im Alter von 15&nbsp;Jahren und älter,
+  die sexueller Gewalt durch andere Personen als einen Intimpartner in den vergangenen
+  12&nbsp;Monaten ausgesetzt waren, nach Alter und Ort des Geschehens
+5.3.1-title: Anteil der 20- bis 24-jährigen Frauen, die vor einem Alter von 15 oder
+  18 Jahren verheiratet oder in einer vergleichbaren Verbindung waren
+5.3.2-title: Anteil der Mädchen und Frauen im Alter von 15-49&nbsp;Jahren, die weiblicher
+  Genitalverstümmelung unterzogen wurden, nach Alter
+5.4.1-title: Anteil des Zeitaufwands für unbezahlte Haus- und Pflegearbeit, nach Geschlecht,
+  Alter und Ort
+5.5.1-title: Frauenanteil in (a) nationalen Parlamenten und (b) lokalen Regierungen
+5.5.2-title: Frauenanteil an  Führungspositionen
+5.6.1-title: Anteil der Frauen im Alter von 15-49 Jahren, die eigenständig fundierte
+  Entscheidungen über sexuelle Beziehungen, Verhütung und reproduktive Gesundheitsversorgung
+  treffen
+5.6.2-title: Anzahl der Staaten mit Gesetzen und Vorschriften, die einen uneingeschränkten
+  und gleichberechtigten Zugang für Frauen und Männer im Alter von 15 Jahren und älter
+  zu sexuellen und reproduktiven Gesundheitsleistungen, Information und Bildung garantieren
+5.a.1-title: (a) Anteil der gesamten landwirtschaftlichen Bevölkerung mit Eigentum
+  oder sicheren Rechten an landwirtschaftlichen Flächen, nach Geschlecht; und (b)
+  Anteil der Frauen an den Eigentümern oder Rechteinhabern landwirtschaftlicher Flächen,
+  nach Art der Eigentumsverhältnisse
+5.a.2-title: Anteil der Staaten, in denen der Rechtsrahmen (einschließlich Gewohnheitsrecht)
+  Frauen die gleichen Rechte auf Landeigentum und/oder -nutzung garantiert
+5.b.1-title: Anteil der Personen, die ein Mobiltelefon besitzen, nach Geschlecht
+5.c.1-title: Anteil der Staaten mit Systemen zur transparenten Verfolgung und Veröffentlichung
+  von Zuwendungen für Geschlechtergleichstellung und Stärkung der Rolle der Frau
+6.1.1-title: Anteil der Bevölkerung mit Zugang zu einer sicheren Trinkwasserversorgung
+6.2.1-title: Anteil der Bevölkerung mit (a) Zugang zu sicherer Sanitärversorgung und
+  (b) einem Handwaschbecken mit Seife und Wasser
+6.3.1-title: Anteil des sicher behandelten Abwassers
+6.3.2-title: Anteil der Gewässer mit guter Wasserqualität
+6.4.1-title: Veränderung der Wassernutzungseffizienz im Zeitablauf
+6.4.2-title: 'Grad der Wasserknappheit: Süßwasserentnahme als Anteil an den verfügbaren
+  Süßwasserressourcen'
+6.5.1-title: Grad der Umsetzung eines integrierten Wasserressourcenmanagements (0-100)
+6.5.2-title: Anteil der grenzüberschreitenden Flussgebiete mit einer operativen Vereinbarung
+  zur Wasserkooperation
+6.6.1-title: Veränderung des Umfangs wasserbezogener Ökosysteme im Zeitablauf
+6.a.1-title: Betrag der wasser- und sanitärbezogenen öffentlichen Entwicklungszusammenarbeit
+  (ODA), die Teil eines geregelten öffentlichen Haushaltsplans ist
+6.b.1-title: Anteil der lokalen Verwaltungseinheiten mit etablierten und operativen
+  Strategien und Verfahren zur Beteiligung der Gemeinden am Wasser- und Abwassermanagement
+7.1.1-title: Anteil der Bevölkerung mit Zugang zu Elektrizität
+7.1.2-title: Anteil der Bevölkerung mit überwiegender Abhängigkeit von sauberen Energieträgern
+  und Technologien
+7.2.1-title: Anteil der erneuerbaren Energien am gesamten Endenergieverbrauch
+7.3.1-title: Energieintensität gemessen als Primärenergie zum BIP
+7.a.1-title: Internationale Finanzströme an Entwicklungsländer zur Förderung von Forschung
+  und Entwicklung im Bereich sauberer Energien sowie erneuerbarer Energieproduktion,
+  einschließlich Hybridsystemen
+7.b.1-title: Investitionen in Energieeffizienz als Anteil am BIP und der Betrag der
+  ausländischen Direktinvestitionen in Form von Finanzmitteln für Infrastruktur und
+  Technologien der Dienstleistungen für nachhaltige Entwicklung
+8.1.1-title: Jährliche Wachstumsrate des realen BIP pro Kopf
+8.10.1-title: (a) Anzahl der Bankfilialen je 100&nbsp;000 Erwachsener und (b) Anzahl
+  der Geldautomaten je 100&nbsp;000 Erwachsener
+8.10.2-title: Anteil der Erwachsenen (15 Jahre und älter) mit einem Konto bei einer
+  Bank oder einem anderen Finanzinstitut oder einem mobilen Gelddienstleistungsanbieter
+8.2.1-title: Jährliche Wachstumsrate des realen BIP je Beschäftigtem
+8.3.1-title: Anteil der informellen Beschäftigung an allen Beschäftigungsverhältnissen
+  außerhalb der Landwirtschaft, nach Geschlecht
+8.4.1-title: Rohstoff-Fußabdruck, Rohstoff-Fußabdruck pro Kopf und Rohstoff-Fußabdruck
+  pro BIP
+8.4.2-title: Inländischer Materialverbrauch, inländischer Materialverbrauch pro Kopf
+  und inländischer Materialverbrauch pro BIP
+8.5.1-title: Durchschnittlicher Stundenlohn von weiblichen und männlichen Beschäftigten,
+  nach Beruf, Alter und Menschen mit Behinderungen
+8.5.2-title: Arbeitslosenquote, nach Geschlecht, Alter und Personen mit Behinderungen
+8.6.1-title: Anteil der Jugendlichen (im Alter von 15-24&nbsp;Jahren), die nicht in
+  schulischer Ausbildung, in Beschäftigung oder Berufsaus- oder -weiterbildung sind
+8.7.1-title: Anteil und Anzahl der Kinder im Alter von 5-17&nbsp;Jahren, die Kinderarbeit
+  verrichten, nach Geschlecht und Alter
+8.8.1-title: Häufigkeitsraten von tödlichen und nicht-tödlichen Arbeitsunfällen, nach
+  Geschlecht und Migrationsstatus
+8.8.2-title: Grad der nationalen Einhaltung der Arbeitnehmerrechte (Vereinigungsfreiheit
+  und Tarifverhandlungen) basierend auf Textquellen der Internationalen Arbeitsorganisation
+  (ILO) und nationaler Gesetzesgrundlagen, nach Geschlecht und Migrationsstatus
+8.9.1-title: Direktes BIP des Tourismus als Anteil am gesamten BIP und als Wachstumsrate
+8.9.2-title: Anteil der Arbeitsplätze im nachhaltigen Tourismus an den gesamten Arbeitsplätzen
+  im Tourismusbereich
+8.a.1-title: Aid for Trade-Zusagen und -Auszahlungen
+8.b.1-title: Existenz einer entwickelten und operationalisierten nationalen Strategie
+  zu Jugendbeschäftigung , als eigenständige Strategie oder als Teil einer nationalen
+  Beschäftigungsstrategie
+9.1.1-title: Anteil der ländlichen Bevölkerung, die bis zu 2&nbsp;km entfernt von
+  einer ganzjährig befahrbaren Straße lebt
+9.1.2-title: Passagiere und Frachtvolumen, nach der Art des Transports
+9.2.1-title: Wertschöpfung des Verarbeitenden Gewerbes als Anteil am BIP und pro Kopf
+9.2.2-title: Beschäftigung im Verarbeitenden Gewerbe als Anteil an der Beschäftigung
+  insgesamt
+9.3.1-title: Anteil kleiner Unternehmen an der gesamten Wertschöpfung der Industrie
+9.3.2-title: Anteil kleiner Unternehmen mit einem Kredit oder einem Kreditrahmen
+9.4.1-title: CO<sub>2</sub>-Emissionen pro Wertschöpfungseinheit
+9.5.1-title: Ausgaben für Forschung und Entwicklung als Anteil am BIP
+9.5.2-title: Wissenschaftler (in Vollzeit-Äquivalenten) je eine Million Einwohner
+9.a.1-title: Gesamte öffentliche internationale Unterstützung (öffentliche Entwicklungszusammenarbeit
+  (ODA) und sonstige öffentliche Ausgaben) für Infrastruktur
+9.b.1-title: Anteil der Wertschöpfung der Medium- und High-Tech-Industrie an der Wertschöpfung
+  insgesamt
+9.c.1-title: Anteil der Bevölkerung, die durch ein Mobilfunknetz abgedeckt ist, nach
+  Technologie

--- a/translations/de/global_targets.yml
+++ b/translations/de/global_targets.yml
@@ -1,758 +1,590 @@
-'1.1':
-  title: Bis 2030 die extreme Armut - gegenwärtig definiert als der Anteil der Menschen,
-    die mit weniger als 1,25 Dollar pro Tag auskommen müssen - für alle Menschen überall
-    auf der Welt beseitigen
-'1.2':
-  title: Bis 2030 den Anteil der Männer, Frauen und Kinder jeden Alters, die in Armut
-    in all ihren Dimensionen nach der jeweiligen nationalen Definition leben, mindestens
-    um die Hälfte senken
-'1.3':
-  title: Den nationalen Gegebenheiten entsprechende Sozialschutzsysteme und -maßnahmen
-    für alle umsetzen, einschließlich eines Basisschutzes, und bis 2030 eine breite
-    Versorgung der Armen und Schwachen erreichen
-'1.4':
-  title: Bis 2030 sicherstellen, dass alle Männer und Frauen, insbesondere die Armen
-    und Schwachen, die gleichen Rechte auf wirtschaftliche Ressourcen sowie Zugang
-    zu grundlegenden Diensten, Grundeigentum und Verfügungsgewalt über Grund und Boden
-    und sonstigen Vermögensformen, Erbschaften, natürlichen Ressourcen, geeigneten
-    neuen Technologien und Finanzdienstleistungen einschließlich Mikrofinanzierung
-    haben
-'1.5':
-  title: Bis 2030 die Widerstandsfähigkeit der Armen und der Menschen in prekären
-    Situationen erhöhen und ihre Exposition und Anfälligkeit gegenüber klimabedingten
-    Extremereignissen und anderen wirtschaftlichen, sozialen und ökologischen Schocks
-    und Katastrophen verringern
-1.a:
-  title: Eine erhebliche Mobilisierung von Ressourcen aus einer Vielzahl von Quellen
-    gewährleisten, einschließlich durch verbesserte Entwicklungszusammenarbeit, um
-    den Entwicklungsländern und insbesondere den am wenigsten entwickelten Ländern
-    ausreichende und berechenbare Mittel für die Umsetzung von Programmen und Politiken
-    zur Beendigung der Armut in all ihren Dimensionen bereitzustellen
-1.b:
-  title: Auf nationaler, regionaler und internationaler Ebene solide politische Rahmen
-    auf der Grundlage armutsorientierter und geschlechtersensibler Entwicklungsstrategien
-    schaffen, um beschleunigte Investitionen in Maßnahmen zur Beseitigung der Armut
-    zu unterstützen
-'10.1':
-  title: Bis 2030 nach und nach ein über dem nationalen Durchschnitt liegendes Einkommenswachstum
-    der ärmsten 40 Prozent der Bevölkerung erreichen und aufrechterhalten
-'10.2':
-  title: Bis 2030 alle Menschen unabhängig von Alter, Geschlecht, Behinderung, Rasse,
-    Ethnizität, Herkunft, Religion oder wirtschaftlichem oder sonstigem Status zu
-    Selbstbestimmung befähigen und ihre soziale, wirtschaftliche und politische Inklusion
-    fördern
-'10.3':
-  title: Chancengleichheit gewährleisten und Ungleichheit der Ergebnisse reduzieren,
-    namentlich durch die Abschaffung diskriminierender Gesetze, Politiken und Praktiken
-    und die Förderung geeigneter gesetzgeberischer, politischer und sonstiger Maßnahmen
-    in dieser Hinsicht
-'10.4':
-  title: Politische Maßnahmen beschließen, insbesondere fiskalische, lohnpolitische
-    und den Sozialschutz betreffende Maßnahmen, und schrittweise größere Gleichheit
-    erzielen
-'10.5':
-  title: Die Regulierung und Überwachung der globalen Finanzmärkte und -institutionen
-    verbessern und die Anwendung der einschlägigen Vorschriften verstärken
-'10.6':
-  title: Eine bessere Vertretung und verstärkte Mitsprache der Entwicklungsländer
-    bei der Entscheidungsfindung in den globalen internationalen Wirtschafts- und
-    Finanzinstitutionen sicherstellen, um die Wirksamkeit, Glaubwürdigkeit, Rechenschaftslegung
-    und Legitimation dieser Institutionen zu erhöhen
-'10.7':
-  title: Eine geordnete, sichere, reguläre und verantwortungsvolle Migration und Mobilität
-    von Menschen erleichtern, unter anderem durch die Anwendung einer planvollen und
-    gut gesteuerten Migrationspolitik
-10.a:
-  title: Den Grundsatz der besonderen und differenzierten Behandlung der Entwicklungsländer,
-    insbesondere der am wenigsten entwickelten Länder, im Einklang mit den Übereinkünften
-    der Welthandelsorganisation anwenden
-10.b:
-  title: Öffentliche Entwicklungshilfe und Finanzströme einschließlich ausländischer
-    Direktinvestitionen in die Staaten fördern, in denen der Bedarf am größten ist,
-    insbesondere in die am wenigsten entwickelten Länder, die afrikanischen Länder,
-    die kleinen Inselentwicklungsländer und die Binnenentwicklungsländer, im Einklang
-    mit ihren jeweiligen nationalen Plänen und Programmen
-10.c:
-  title: Bis 2030 die Transaktionskosten für Heimatüberweisungen von Migranten auf
-    weniger als 3 Prozent senken und Überweisungskorridore mit Kosten von über 5 Prozent
-    beseitigen
-'11.1':
-  title: Bis 2030 den Zugang zu angemessenem, sicherem und bezahlbarem Wohnraum und
-    zur Grundversorgung für alle sicherstellen und Slums sanieren
-'11.2':
-  title: Bis 2030 den Zugang zu sicheren, bezahlbaren, zugänglichen und nachhaltigen
-    Verkehrssystemen für alle ermöglichen und die Sicherheit im Straßenverkehr verbessern,
-    insbesondere durch den Ausbau des öffentlichen Verkehrs, mit besonderem Augenmerk
-    auf den Bedürfnissen von Menschen in prekären Situationen, Frauen, Kindern, Menschen
-    mit Behinderungen und älteren Menschen
-'11.3':
-  title: Bis 2030 die Verstädterung inklusiver und nachhaltiger gestalten und die
-    Kapazitäten für eine partizipatorische, integrierte und nachhaltige Siedlungsplanung
-    und -steuerung in allen Ländern verstärken
-'11.4':
-  title: Die Anstrengungen zum Schutz und zur Wahrung des Weltkultur- und -naturerbes
-    verstärken
-'11.5':
-  title: Bis 2030 die Zahl der durch Katastrophen, einschließlich Wasserkatastrophen,
-    bedingten Todesfälle und der davon betroffenen Menschen deutlich reduzieren und
-    die dadurch verursachten unmittelbaren wirtschaftlichen Verluste im Verhältnis
-    zum globalen Bruttoinlandsprodukt wesentlich verringern, mit Schwerpunkt auf dem
-    Schutz der Armen und von Menschen in prekären Situationen
-'11.6':
-  title: Bis 2030 die von den Städten ausgehende Umweltbelastung pro Kopf senken,
-    unter anderem mit besonderer Aufmerksamkeit auf der Luftqualität und der kommunalen
-    und sonstigen Abfallbehandlung
-'11.7':
-  title: Bis 2030 den allgemeinen Zugang zu sicheren, inklusiven und zugänglichen
-    Grünflächen und öffentlichen Räumen gewährleisten, insbesondere für Frauen und
-    Kinder, ältere Menschen und Menschen mit Behinderungen
-11.a:
-  title: Durch eine verstärkte nationale und regionale Entwicklungsplanung positive
-    wirtschaftliche, soziale und ökologische Verbindungen zwischen städtischen, stadtnahen
-    und ländlichen Gebieten unterstützen
-11.b:
-  title: Bis 2020 die Zahl der Städte und Siedlungen, die integrierte Politiken und
-    Pläne zur Förderung der Inklusion, der Ressourceneffizienz, der Abschwächung des
-    Klimawandels, der Klimaanpassung und der Widerstandsfähigkeit gegenüber Katastrophen
-    beschließen und umsetzen, wesentlich erhöhen und gemäß dem Sendai-Rahmen für Katastrophenvorsorge
-    2015-2030 ein ganzheitliches Katastrophenrisikomanagement auf allen Ebenen entwickeln
-    und umsetzen
-11.c:
-  title: Die am wenigsten entwickelten Länder unter anderem durch finanzielle und
-    technische Hilfe beim Bau nachhaltiger und widerstandsfähiger Gebäude unter Nutzung
-    einheimischer Materialien unterstützen
-'12.1':
-  title: Den Zehnjahres-Programmrahmen für nachhaltige Konsum- und Produktionsmuster
-    umsetzen, wobei alle Länder, an der Spitze die entwickelten Länder, Maßnahmen
-    ergreifen, unter Berücksichtigung des Entwicklungsstands und der Kapazitäten der
-    Entwicklungsländer
-'12.2':
-  title: Bis 2030 die nachhaltige Bewirtschaftung und effiziente Nutzung der natürlichen
-    Ressourcen erreichen
-'12.3':
-  title: Bis 2030 die weltweite Nahrungsmittelverschwendung pro Kopf auf Einzelhandels-
-    und Verbraucherebene halbieren und die entlang der Produktions- und Lieferkette
-    entstehenden Nahrungsmittelverluste einschließlich Nachernteverlusten verringern
-'12.4':
-  title: Bis 2020 einen umweltverträglichen Umgang mit Chemikalien und allen Abfällen
-    während ihres gesamten Lebenszyklus in Übereinstimmung mit den vereinbarten internationalen
-    Rahmenregelungen erreichen und ihre Freisetzung in Luft, Wasser und Boden erheblich
-    verringern, um ihre nachteiligen Auswirkungen auf die menschliche Gesundheit und
-    die Umwelt auf ein Mindestmaß zu beschränken
-'12.5':
-  title: Bis 2030 das Abfallaufkommen durch Vermeidung, Verminderung, Wiederverwertung
-    und Wiederverwendung deutlich verringern
-'12.6':
-  title: Die Unternehmen, insbesondere große und transnationale Unternehmen, dazu
-    ermutigen, nachhaltige Verfahren einzuführen und in ihre Berichterstattung Nachhaltigkeitsinformationen
-    aufzunehmen
-'12.7':
-  title: In der öffentlichen Beschaffung nachhaltige Verfahren fördern, im Einklang
-    mit den nationalen Politiken und Prioritäten
-'12.8':
-  title: Bis 2030 sicherstellen, dass die Menschen überall über einschlägige Informationen
-    und das Bewusstsein für nachhaltige Entwicklung und eine Lebensweise in Harmonie
-    mit der Natur verfügen
-12.a:
-  title: Die Entwicklungsländer bei der Stärkung ihrer wissenschaftlichen und technologischen
-    Kapazitäten im Hinblick auf den Übergang zu nachhaltigeren Konsum- und Produktionsmustern
-    unterstützen
-12.b:
-  title: Instrumente zur Beobachtung der Auswirkungen eines nachhaltigen Tourismus,
-    der Arbeitsplätze schafft und die lokale Kultur und lokale Produkte fördert, auf
-    die nachhaltige Entwicklung entwickeln und anwenden
-12.c:
-  title: Die ineffiziente Subventionierung fossiler Brennstoffe, die zu verschwenderischem
-    Verbrauch verleitet, durch Beseitigung von Marktverzerrungen entsprechend den
-    nationalen Gegebenheiten rationalisieren, unter anderem durch eine Umstrukturierung
-    der Besteuerung und die allmähliche Abschaffung dieser schädlichen Subventionen,
-    um ihren Umweltauswirkungen Rechnung zu tragen, wobei die besonderen Bedürfnisse
-    und Gegebenheiten der Entwicklungsländer in vollem Umfang berücksichtigt und die
-    möglichen nachteiligen Auswirkungen auf ihre Entwicklung in einer die Armen und
-    die betroffenen Gemeinwesen schützenden Weise so gering wie möglich gehalten werden
-'13.1':
-  title: Die Widerstandskraft und die Anpassungsfähigkeit gegenüber klimabedingten
-    Gefahren und Naturkatastrophen in allen Ländern stärken
-'13.2':
-  title: Klimaschutzmaßnahmen in die nationalen Politiken, Strategien und Planungen
-    einbeziehen
-'13.3':
-  title: Die Aufklärung und Sensibilisierung sowie die personellen und institutionellen
-    Kapazitäten im Bereich der Abschwächung des Klimawandels, der Klimaanpassung,
-    der Reduzierung der Klimaauswirkungen sowie der Frühwarnung verbessern
-13.a:
-  title: Die Verpflichtung erfüllen, die von den Vertragsparteien des Rahmenübereinkommens
-    der Vereinten Nationen über Klimaänderungen, die entwickelte Länder sind, übernommen
-    wurde, bis 2020 gemeinsam jährlich 100 Milliarden Dollar aus allen Quellen aufzubringen,
-    um den Bedürfnissen der Entwicklungsländer im Kontext sinnvoller Klimaschutzmaßnahmen
-    und einer transparenten Umsetzung zu entsprechen, und den Grünen Klimafonds vollständig
-    zu operationalisieren, indem er schnellstmöglich mit den erforderlichen Finanzmitteln
-    ausgestattet wird
-13.b:
-  title: Mechanismen zum Ausbau effektiver Planungs- und Managementkapazitäten im
-    Bereich des Klimawandels in den am wenigsten entwickelten Ländern und kleinen
-    Inselentwicklungsländern fördern, unter anderem mit gezielter Ausrichtung auf
-    Frauen, junge Menschen sowie lokale und marginalisierte Gemeinwesen
-'14.1':
-  title: Bis 2025 alle Arten der Meeresverschmutzung, insbesondere durch vom Lande
-    ausgehende Tätigkeiten und namentlich Meeresmüll und Nährstoffbelastung, verhüten
-    und erheblich verringern
-'14.2':
-  title: Bis 2020 die Meeres- und Küstenökosysteme nachhaltig bewirtschaften und schützen,
-    um unter anderem durch Stärkung ihrer Resilienz erhebliche nachteilige Auswirkungen
-    zu vermeiden, und Maßnahmen zu ihrer Wiederherstellung ergreifen, damit die Meere
-    wieder gesund und produktiv werden
-'14.3':
-  title: Die Versauerung der Ozeane auf ein Mindestmaß reduzieren und ihre Auswirkungen
-    bekämpfen, unter anderem durch eine verstärkte wissenschaftliche Zusammenarbeit
-    auf allen Ebenen
-'14.4':
-  title: Bis 2020 die Fangtätigkeit wirksam regeln und die Überfischung, die illegale,
-    ungemeldete und unregulierte Fischerei und zerstörerische Fangpraktiken beenden
-    und wissenschaftlich fundierte Bewirtschaftungspläne umsetzen, um die Fischbestände
-    in kürzestmöglicher Zeit mindestens auf einen Stand zurückzuführen, der den höchstmöglichen
-    Dauerertrag unter Berücksichtigung ihrer biologischen Merkmale sichert
-'14.5':
-  title: Bis 2020 mindestens 10 Prozent der Küsten- und Meeresgebiete im Einklang
-    mit dem nationalen Recht und dem Völkerrecht und auf der Grundlage der besten
-    verfügbaren wissenschaftlichen Informationen erhalten
-'14.6':
-  title: Bis 2020 bestimmte Formen der Fischereisubventionen untersagen, die zu Überkapazitäten
-    und Überfischung beitragen, Subventionen abschaffen, die zu illegaler, ungemeldeter
-    und unregulierter Fischerei beitragen, und keine neuen derartigen Subventionen
-    einführen, in Anerkennung dessen, dass eine geeignete und wirksame besondere und
-    differenzierte Behandlung der Entwicklungsländer und der am wenigsten entwickelten
-    Länder einen untrennbaren Bestandteil der im Rahmen der Welthandelsorganisation
-    geführten Verhandlungen über Fischereisubventionen bilden sollte
-'14.7':
-  title: Bis 2030 die sich aus der nachhaltigen Nutzung der Meeresressourcen ergebenden
-    wirtschaftlichen Vorteile für die kleinen Inselentwicklungsländer und die am wenigsten
-    entwickelten Länder erhöhen, namentlich durch nachhaltiges Management der Fischerei,
-    der Aquakultur und des Tourismus
-14.a:
-  title: Die wissenschaftlichen Kenntnisse vertiefen, die Forschungskapazitäten ausbauen
-    und Meerestechnologien weitergeben, unter Berücksichtigung der Kriterien und Leitlinien
-    der Zwischenstaatlichen Ozeanographischen Kommission für die Weitergabe von Meerestechnologie,
-    um die Gesundheit der Ozeane zu verbessern und den Beitrag der biologischen Vielfalt
-    der Meere zur Entwicklung der Entwicklungsländer, insbesondere der kleinen Inselentwicklungsländer
-    und der am wenigsten entwickelten Länder, zu verstärken
-14.b:
-  title: Den Zugang der handwerklichen Kleinfischer zu den Meeresressourcen und Märkten
-    gewährleisten
-14.c:
-  title: "Die Erhaltung und nachhaltige Nutzung der Ozeane und ihrer Ressourcen verbessern\
-    \ und zu diesem Zweck das Völkerrecht umsetzen, wie es im Seerechtsübereinkommen\
-    \ der Vereinten Nationen niedergelegt ist, das den rechtlichen Rahmen für die\
-    \ Erhaltung und nachhaltige Nutzung der Ozeane und ihrer Ressourcen vorgibt, worauf\
-    \ in Ziffer 158 des Dokuments \x84Die Zukunft, die wir wollen\x93 hingewiesen\
-    \ wird"
-'15.1':
-  title: Bis 2020 im Einklang mit den Verpflichtungen aus internationalen Übereinkünften
-    die Erhaltung, Wiederherstellung und nachhaltige Nutzung der Land- und Binnensüßwasser-
-    Ökosysteme und ihrer Dienstleistungen, insbesondere der Wälder, der Feuchtgebiete,
-    der Berge und der Trockengebiete, gewährleisten
-'15.2':
-  title: Bis 2020 die nachhaltige Bewirtschaftung aller Waldarten fördern, die Entwaldung
-    beenden, geschädigte Wälder wiederherstellen und die Aufforstung und Wiederaufforstung
-    weltweit beträchtlich erhöhen
-'15.3':
-  title: Bis 2030 die Wüstenbildung bekämpfen, die geschädigten Flächen und Böden
-    einschließlich der von Wüstenbildung, Dürre und Überschwemmungen betroffenen Flächen
-    sanieren und eine Welt anstreben, in der die Landverödung neutralisiert wird
-'15.4':
-  title: Bis 2030 die Erhaltung der Bergökosysteme einschließlich ihrer biologischen
-    Vielfalt sicherstellen, um ihre Fähigkeit zur Erbringung wesentlichen Nutzens
-    für die nachhaltige Entwicklung zu stärken
-'15.5':
-  title: Umgehende und bedeutende Maßnahmen ergreifen, um die Verschlechterung der
-    natürlichen Lebensräume zu verringern, dem Verlust der biologischen Vielfalt ein
-    Ende zu setzen und bis 2020 die bedrohten Arten zu schützen und ihr Aussterben
-    zu verhindern
-'15.6':
-  title: Die ausgewogene und gerechte Aufteilung der sich aus der Nutzung der genetischen
-    Ressourcen ergebenden Vorteile und den angemessenen Zugang zu diesen Ressourcen
-    fördern, wie auf internationaler Ebene vereinbart
-'15.7':
-  title: Dringend Maßnahmen ergreifen, um der Wilderei und dem Handel mit geschützten
-    Pflanzen- und Tierarten ein Ende zu setzen und dem Problem des Angebots illegaler
-    Produkte aus wildlebenden Pflanzen und Tieren und der Nachfrage danach zu begegnen
-'15.8':
-  title: Bis 2020 Maßnahmen einführen, um das Einbringen invasiver gebietsfremder
-    Arten zu verhindern, ihre Auswirkungen auf die Land- und Wasserökosysteme deutlich
-    zu reduzieren und die prioritären Arten zu kontrollieren oder zu beseitigen
-'15.9':
-  title: Bis 2020 Ökosystem- und Biodiversitätswerte in die nationalen und lokalen
-    Planungen, Entwicklungsprozesse, Armutsbekämpfungsstrategien und Gesamtrechnungssysteme
-    einbeziehen
-15.a:
-  title: Finanzielle Mittel aus allen Quellen für die Erhaltung und nachhaltige Nutzung
-    der biologischen Vielfalt und der Ökosysteme aufbringen und deutlich erhöhen
-15.b:
-  title: Erhebliche Mittel aus allen Quellen und auf allen Ebenen für die Finanzierung
-    einer nachhaltigen Bewirtschaftung der Wälder aufbringen und den Entwicklungsländern
-    geeignete Anreize für den vermehrten Einsatz dieser Bewirtschaftungsform bieten,
-    namentlich zum Zweck der Walderhaltung und Wiederaufforstung
-15.c:
-  title: Die weltweite Unterstützung von Maßnahmen zur Bekämpfung der Wilderei und
-    des Handels mit geschützten Arten verstärken, unter anderem durch die Stärkung
-    der Fähigkeit lokaler Gemeinwesen, Möglichkeiten einer nachhaltigen Existenzsicherung
-    zu nutzen
-'16.1':
-  title: Alle Formen der Gewalt und die gewaltbedingte Sterblichkeit überall deutlich
-    verringern
-'16.10':
-  title: Den öffentlichen Zugang zu Informationen gewährleisten und die Grundfreiheiten
-    schützen, im Einklang mit den nationalen Rechtsvorschriften und völkerrechtlichen
-    Übereinkünften
-'16.2':
-  title: Missbrauch und Ausbeutung von Kindern, den Kinderhandel, Folter und alle
-    Formen von Gewalt gegen Kinder beenden
-'16.3':
-  title: Die Rechtsstaatlichkeit auf nationaler und internationaler Ebene fördern
-    und den gleichberechtigten Zugang aller zur Justiz gewährleisten
-'16.4':
-  title: Bis 2030 illegale Finanz- und Waffenströme deutlich verringern, die Wiedererlangung
-    und Rückgabe gestohlener Vermögenswerte verstärken und alle Formen der organisierten
-    Kriminalität bekämpfen
-'16.5':
-  title: Korruption und Bestechung in allen ihren Formen erheblich reduzieren
-'16.6':
-  title: Leistungsfähige, rechenschaftspflichtige und transparente Institutionen auf
-    allen Ebenen aufbauen
-'16.7':
-  title: Dafür sorgen, dass die Entscheidungsfindung auf allen Ebenen bedarfsorientiert,
-    inklusiv, partizipatorisch und repräsentativ ist
-'16.8':
-  title: Die Teilhabe der Entwicklungsländer an den globalen Lenkungsinstitutionen
-    erweitern und verstärken
-'16.9':
-  title: Bis 2030 insbesondere durch die Registrierung der Geburten dafür sorgen,
-    dass alle Menschen eine rechtliche Identität haben
-16.a:
-  title: Die zuständigen nationalen Institutionen namentlich durch internationale
-    Zusammenarbeit beim Kapazitätsaufbau auf allen Ebenen zur Verhütung von Gewalt
-    und zur Bekämpfung von Terrorismus und Kriminalität unterstützen, insbesondere
-    in den Entwicklungsländern
-16.b:
-  title: Nichtdiskriminierende Rechtsvorschriften und Politiken zugunsten einer nachhaltigen
-    Entwicklung fördern und durchsetzen
-'17.1':
-  title: Die Mobilisierung einheimischer Ressourcen verstärken, einschließlich durch
-    internationale Unterstützung für die Entwicklungsländer, um die nationalen Kapazitäten
-    zur Erhebung von Steuern und anderen Abgaben zu verbessern
-'17.10':
-  title: Ein universales, regelgestütztes, offenes, nichtdiskriminierendes und gerechtes
-    multilaterales Handelssystem unter dem Dach der Welthandelsorganisation fördern,
-    insbesondere durch den Abschluss der Verhandlungen im Rahmen ihrer Entwicklungsagenda
-    von Doha
-'17.11':
-  title: Die Exporte der Entwicklungsländer deutlich erhöhen, insbesondere mit Blick
-    darauf, den Anteil der am wenigsten entwickelten Länder an den weltweiten Exporten
-    bis 2020 zu verdoppeln
-'17.12':
-  title: Die rasche Umsetzung des zoll- und kontingentfreien Marktzugangs auf dauerhafter
-    Grundlage für alle am wenigsten entwickelten Länder im Einklang mit den Beschlüssen
-    der Welthandelsorganisation erreichen, unter anderem indem sichergestellt wird,
-    dass die für Importe aus den am wenigsten entwickelten Ländern geltenden präferenziellen
-    Ursprungsregeln transparent und einfach sind und zur Erleichterung des Marktzugangs
-    beitragen
-'17.13':
-  title: Die globale makroökonomische Stabilität verbessern, namentlich durch Politikkoordinierung
-    und Politikkohärenz
-'17.14':
-  title: Die Politikkohärenz zugunsten nachhaltiger Entwicklung verbessern
-'17.15':
-  title: Den politischen Spielraum und die Führungsrolle jedes Landes bei der Festlegung
-    und Umsetzung von Politiken zur Armutsbeseitigung und für nachhaltige Entwicklung
-    respektieren
-'17.16':
-  title: Die Globale Partnerschaft für nachhaltige Entwicklung ausbauen, ergänzt durch
-    Multi-Akteur-Partnerschaften zur Mobilisierung und zum Austausch von Wissen, Fachkenntnissen,
-    Technologie und finanziellen Ressourcen, um die Erreichung der Ziele für nachhaltige
-    Entwicklung in allen Ländern und insbesondere in den Entwicklungsländern zu unterstützen
-'17.17':
-  title: Die Bildung wirksamer öffentlicher, öffentlich-privater und zivilgesellschaftlicher
-    Partnerschaften aufbauend auf den Erfahrungen und Mittelbeschaffungsstrategien
-    bestehender Partnerschaften unterstützen und fördern
-'17.18':
-  title: Bis 2020 die Unterstützung des Kapazitätsaufbaus für die Entwicklungsländer
-    und namentlich die am wenigsten entwickelten Länder und die kleinen Inselentwicklungsländer
-    erhöhen, mit dem Ziel, über erheblich mehr hochwertige, aktuelle und verlässliche
-    Daten zu verfügen, die nach Einkommen, Geschlecht, Alter, Rasse, Ethnizität, Migrationsstatus,
-    Behinderung, geografischer Lage und sonstigen im nationalen Kontext relevanten
-    Merkmalen aufgeschlüsselt sind
-'17.19':
-  title: Bis 2030 auf den bestehenden Initiativen aufbauen, um Fortschrittsmaße für
-    nachhaltige Entwicklung zu erarbeiten, die das Bruttoinlandsprodukt ergänzen,
-    und den Aufbau der statistischen Kapazitäten der Entwicklungsländer unterstützen
-'17.2':
-  title: Sicherstellen, dass die entwickelten Länder ihre Zusagen im Bereich der öffentlichen Entwicklungshilfe voll einhalten, einschließlich der von vielen entwickelten Ländern eingegangenen Verpflichtung, die Zielvorgabe von 0,7 Prozent ihres Bruttonationaleinkommens für öffentliche Entwicklungshilfe zugunsten der Entwicklungsländer und 0,15 bis 0,20 Prozent zugunsten der am wenigsten entwickelten Länder zu erreichen; den Gebern öffentlicher Entwicklungshilfe wird nahegelegt, die Bereitstellung von mindestens 0,20&nbsp;Prozent ihres Bruttonationaleinkommens zugunsten der am wenigsten entwickelten Länder als Zielsetzung zu erwägen
-'17.3':
-  title: Zusätzliche finanzielle Mittel aus verschiedenen Quellen für die Entwicklungsländer
-    mobilisieren
-'17.4':
-  title: Den Entwicklungsländern dabei behilflich sein, durch eine koordinierte Politik
-    zur Förderung der Schuldenfinanzierung, der Entschuldung beziehungsweise der Umschuldung
-    die langfristige Tragfähigkeit der Verschuldung zu erreichen, und das Problem
-    der Auslandsverschuldung hochverschuldeter armer Länder angehen, um die Überschuldung
-    zu verringern
-'17.5':
-  title: Investitionsförderungssysteme für die am wenigsten entwickelten Länder beschließen
-    und umsetzen
-'17.6':
-  title: Die regionale und internationale Nord-Süd- und Süd-Süd-Zusammenarbeit und
-    Dreieckskooperation im Bereich Wissenschaft, Technologie und Innovation und den
-    Zugang dazu verbessern und den Austausch von Wissen zu einvernehmlich festgelegten
-    Bedingungen verstärken, unter anderem durch eine bessere Abstimmung zwischen den
-    vorhandenen Mechanismen, insbesondere auf Ebene der Vereinten Nationen, und durch
-    einen globalen Mechanismus zur Technologieförderung
-'17.7':
-  title: Die Entwicklung, den Transfer, die Verbreitung und die Diffusion von umweltverträglichen
-    Technologien an die Entwicklungsländer zu gegenseitig vereinbarten günstigen Bedingungen,
-    einschließlich Konzessions- und Vorzugsbedingungen, fördern
-'17.8':
-  title: Die Technologiebank und den Mechanismus zum Kapazitätsaufbau für Wissenschaft,
-    Technologie und Innovation für die am wenigsten entwickelten Länder bis 2017 vollständig
-    operationalisieren und die Nutzung von Grundlagentechnologien, insbesondere der
-    Informations- und Kommunikationstechnologien, verbessern
-'17.9':
-  title: Die internationale Unterstützung für die Durchführung eines effektiven und
-    gezielten Kapazitätsaufbaus in den Entwicklungsländern verstärken, um die nationalen
-    Pläne zur Umsetzung aller Ziele für nachhaltige Entwicklung zu unterstützen, namentlich
-    im Rahmen der Nord-Süd- und Süd-Süd-Zusammenarbeit und der Dreieckskooperation
-'2.1':
-  title: Bis 2030 den Hunger beenden und sicherstellen, dass alle Menschen, insbesondere
-    die Armen und Menschen in prekären Situationen, einschließlich Kleinkindern, ganzjährig
-    Zugang zu sicheren, nährstoffreichen und ausreichenden Nahrungsmitteln haben
-'2.2':
-  title: Bis 2030 alle Formen der Mangelernährung beenden, einschließlich durch Erreichung
-    der international vereinbarten Zielvorgaben in Bezug auf Wachstumshemmung und
-    Auszehrung bei Kindern unter 5&nbsp;Jahren bis 2025, und den Ernährungsbedürfnissen
-    von heranwachsenden Mädchen, schwangeren und stillenden Frauen und älteren Menschen
-    Rechnung tragen
-'2.3':
-  title: Bis 2030 die landwirtschaftliche Produktivität und die Einkommen von kleinen
-    Nahrungsmittel-produzenten, insbesondere von Frauen, Angehörigen indigener Völker,
-    landwirtschaftlichen Familienbetrieben, Weidetierhaltern und Fischern, verdoppeln,
-    unter anderem durch den sicheren und gleichberechtigten Zugang zu Grund und Boden,
-    anderen Produktionsressourcen und Betriebsmitteln, Wissen, Finanzdienstleistungen,
-    Märkten sowie Möglichkeiten für Wertschöpfung und außerlandwirtschaftliche Beschäftigung
-'2.4':
-  title: Bis 2030 die Nachhaltigkeit der Systeme der Nahrungsmittelproduktion sicherstellen
-    und  resiliente landwirtschaftliche Methoden anwenden, die die Produktivität und
-    den Ertrag steigern, zur Erhaltung der Ökosysteme beitragen, die Anpassungsfähigkeit
-    an Klimaänderungen, extreme Wetterereignisse, Dürren, Überschwemmungen und andere
-    Katastrophen erhöhen und die Flächen- und Bodenqualität schrittweise verbessern
-'2.5':
-  title: Bis 2020 die genetische Vielfalt von Saatgut, Kulturpflanzen sowie Nutz-
-    und Haustieren und ihren wildlebenden Artverwandten bewahren, unter anderem durch
-    gut verwaltete und diversifizierte Saatgut- und Pflanzenbanken auf nationaler,
-    regionaler und internationaler Ebene, und den Zugang zu den Vorteilen aus der
-    Nutzung der genetischen Ressourcen und des damit verbundenen traditionellen Wissens
-    sowie die ausgewogene und gerechte Aufteilung dieser Vorteile fördern, wie auf
-    internationaler Ebene vereinbart
-2.a:
-  title: Die Investitionen in die ländliche Infrastruktur, die Agrarforschung und
-    landwirtschaftliche Beratungsdienste, die Technologieentwicklung sowie Genbanken
-    für Pflanzen und Nutztiere erhöhen, unter anderem durch verstärkte internationale
-    Zusammenarbeit, um die landwirtschaftliche Produktionskapazität in den Entwicklungsländern
-    und insbesondere den am wenigsten entwickelten Ländern zu verbessern
-2.b:
-  title: Handelsbeschränkungen und -verzerrungen auf den globalen Agrarmärkten korrigieren
-    und verhindern, unter anderem durch die parallele Abschaffung aller Formen von
-    Agrarexportsubventionen und aller Exportmaßnahmen mit gleicher Wirkung im Einklang
-    mit dem Mandat der Doha-Entwicklungsrunde
-2.c:
-  title: Maßnahmen zur Gewährleistung des reibungslosen Funktionierens der Märkte
-    für Nahrungsmittelrohstoffe und ihre Derivate ergreifen und den raschen Zugang
-    zu Marktinformationen, unter anderem über Nahrungsmittelreserven, erleichtern,
-    um zur Begrenzung der extremen Schwankungen der Nahrungsmittelpreise beizutragen
-'3.1':
-  title: Bis 2030 die weltweite Müttersterblichkeit auf unter 70 je 100&nbsp;000 Lebendgeburten
-    senken
-'3.2':
-  title: Bis 2030 den vermeidbaren Todesfällen bei Neugeborenen und Kindern unter
-    5 Jahren ein Ende setzen, mit dem von allen Ländern zu verfolgenden Ziel, die
-    Sterblichkeit bei Neugeborenen mindestens auf 12 je 1&nbsp;000 Lebendgeburten und bei
-    Kindern unter 5 Jahren mindestens auf 25 je 1&nbsp;000 Lebendgeburten zu senken
-'3.3':
-  title: Bis 2030 die Aids-, Tuberkulose- und Malariaepidemien und die vernachlässigten
-    Tropenkrankheiten beseitigen und Hepatitis, durch Wasser übertragene Krankheiten
-    und andere übertragbare Krankheiten bekämpfen
-'3.4':
-  title: Bis 2030 die Frühsterblichkeit aufgrund von nichtübertragbaren Krankheiten
-    durch Prävention und Behandlung um ein Drittel senken und die psychische Gesundheit
-    und das Wohlergehen fördern
-'3.5':
-  title: Die Prävention und Behandlung des Substanzmissbrauchs, namentlich des Suchtstoffmissbrauchs
-    und des schädlichen Gebrauchs von Alkohol, verstärken
-'3.6':
-  title: Bis 2020 die Zahl der Todesfälle und Verletzungen infolge von Verkehrsunfällen
-    weltweit halbieren
-'3.7':
-  title: Bis 2030 den allgemeinen Zugang zu sexual- und reproduktionsmedizinischer
-    Versorgung, einschließlich Familienplanung, Information und Aufklärung, und die
-    Einbeziehung der reproduktiven Gesundheit in nationale Strategien und Programme
-    gewährleisten
-'3.8':
-  title: Die allgemeine Gesundheitsversorgung, einschließlich der Absicherung gegen
-    finanzielle Risiken, den Zugang zu hochwertigen grundlegenden Gesundheitsdiensten
-    und den Zugang zu sicheren, wirksamen, hochwertigen und bezahlbaren unentbehrlichen
-    Arzneimitteln und Impfstoffen für alle erreichen
-'3.9':
-  title: Bis 2030 die Zahl der Todesfälle und Erkrankungen aufgrund gefährlicher Chemikalien
-    und der Verschmutzung und Verunreinigung von Luft, Wasser und Boden erheblich
-    verringern
-3.a:
-  title: Die Durchführung des Rahmenübereinkommens der Weltgesundheitsorganisation
-    zur Eindämmung des Tabakgebrauchs in allen Ländern nach Bedarf stärken
-3.b:
-  title: Forschung und Entwicklung zu Impfstoffen und Medikamenten für übertragbare
-    und nichtübertragbare Krankheiten, von denen hauptsächlich Entwicklungsländer
-    betroffen sind, unterstützen, den Zugang zu bezahlbaren unentbehrlichen Arzneimitteln
-    und Impfstoffen gewährleisten, im Einklang mit der Erklärung von Doha über das
-    TRIPS-Übereinkommen und die öffentliche Gesundheit, die das Recht der Entwicklungsländer
-    bekräftigt, die Bestimmungen in dem Übereinkommen über handelsbezogene Aspekte
-    der Rechte des geistigen Eigentums über Flexibilitäten zum Schutz der öffentlichen
-    Gesundheit voll auszuschöpfen, und insbesondere den Zugang zu Medikamenten für
-    alle zu gewährleisten
-3.c:
-  title: Die Gesundheitsfinanzierung und die Rekrutierung, Aus- und Weiterbildung
-    und Bindung von Gesundheitsfachkräften in den Entwicklungsländern und insbesondere
-    in den am wenigsten entwickelten Ländern und den kleinen Inselentwicklungsländern
-    deutlich erhöhen
-3.d:
-  title: Die Kapazitäten aller Länder, insbesondere der Entwicklungsländer, in den
-    Bereichen Frühwarnung, Risikominderung und Management nationaler und globaler
-    Gesundheitsrisiken stärken
-'4.1':
-  title: Bis 2030 sicherstellen, dass alle Mädchen und Jungen gleichberechtigt eine
-    kostenlose und hochwertige Grund- und Sekundarschulbildung abschließen, die zu
-    brauchbaren und effektiven Lernergebnissen führt
-'4.2':
-  title: Bis 2030 sicherstellen, dass alle Mädchen und Jungen Zugang zu hochwertiger
-    frühkindlicher Erziehung, Betreuung und Vorschulbildung erhalten, damit sie auf
-    die Grundschule vorbereitet sind
-'4.3':
-  title: Bis 2030 den gleichberechtigten Zugang aller Frauen und Männer zu einer erschwinglichen
-    und hochwertigen fachlichen, beruflichen und tertiären Bildung einschließlich
-    universitärer Bildung gewährleisten
-'4.4':
-  title: Bis 2030 die Zahl der Jugendlichen und Erwachsenen wesentlich erhöhen, die
-    über die entsprechenden Qualifikationen einschließlich fachlicher und beruflicher
-    Qualifikationen für eine Beschäftigung, eine menschenwürdige Arbeit und Unternehmertum
-    verfügen
-'4.5':
-  title: Bis 2030 geschlechtsspezifische Disparitäten in der Bildung beseitigen und
-    den gleichberechtigen Zugang der Schwachen in der Gesellschaft, namentlich von
-    Menschen mit Behinderungen, Angehörigen indigener Völker und Kindern in prekären
-    Situationen, zu allen Bildungs- und Ausbildungsebenen gewährleisten
-'4.6':
-  title: Bis 2030 sicherstellen, dass alle Jugendlichen und ein erheblicher Anteil
-    der männlichen und weiblichen Erwachsenen lesen, schreiben und rechnen lernen
-'4.7':
-  title: Bis 2030 sicherstellen, dass alle Lernenden die notwendigen Kenntnisse und
-    Qualifikationen zur Förderung nachhaltiger Entwicklung erwerben, unter anderem
-    durch Bildung für nachhaltige Entwicklung und nachhaltige Lebensweisen, Menschenrechte,
-    Geschlechtergleichstellung, eine Kultur des Friedens und der Gewaltlosigkeit,
-    Weltbürgerschaft und die Wertschätzung kultureller Vielfalt und des Beitrags der
-    Kultur zu nachhaltiger Entwicklung
-4.a:
-  title: Bildungseinrichtungen bauen und ausbauen, die kinder-, behinderten- und geschlechtergerecht
-    sind und eine sichere, gewaltfreie, inklusive und effektive Lernumgebung für alle
-    bieten
-4.b:
-  title: Bis 2020 weltweit die Zahl der verfügbaren Stipendien für Entwicklungsländer,
-    insbesondere für die am wenigsten entwickelten Länder, die kleinen Inselentwicklungsländer
-    und die afrikanischen Länder, zum Besuch einer Hochschule, einschließlich zur
-    Berufsbildung und zu Informations- und Kommunikationstechnik-, Technik-, Ingenieurs-
-    und Wissenschaftsprogrammen, in entwickelten Ländern und in anderen Entwicklungsländern
-    wesentlich erhöhen
-4.c:
-  title: Bis 2030 das Angebot an qualifizierten Lehrkräften unter anderem durch internationale
-    Zusammenarbeit im Bereich der Lehrerausbildung in den Entwicklungsländern und
-    insbesondere in den am wenigsten entwickelten Ländern und kleinen Inselentwicklungsländern
-    wesentlich erhöhen
-'5.1':
-  title: Alle Formen der Diskriminierung von Frauen und Mädchen überall auf der Welt
-    beenden
-'5.2':
-  title: Alle Formen von Gewalt gegen alle Frauen und Mädchen im öffentlichen und
-    im privaten Bereich einschließlich des Menschenhandels und sexueller und anderer
-    Formen der Ausbeutung beseitigen
-'5.3':
-  title: Alle schädlichen Praktiken wie Kinderheirat, Frühverheiratung und Zwangsheirat
-    sowie die Genitalverstümmelung bei Frauen und Mädchen beseitigen
-'5.4':
-  title: Unbezahlte Pflege- und Hausarbeit durch die Bereitstellung öffentlicher
-    Dienstleistungen und Infrastrukturen, Sozialschutzmaßnahmen und die Förderung
-    geteilter Verantwortung innerhalb des Haushalts und der Familie entsprechend den
-    nationalen Gegebenheiten anerkennen und wertschätzen
-'5.5':
-  title: Die volle und wirksame Teilhabe von Frauen und ihre Chancengleichheit bei
-    der Übernahme von Führungsrollen auf allen Ebenen der Entscheidungsfindung im
-    politischen, wirtschaftlichen und öffentlichen Leben sicherstellen
-'5.6':
-  title: Den allgemeinen Zugang zu sexueller und reproduktiver Gesundheit und reproduktiven
-    Rechten gewährleisten, wie im Einklang mit dem Aktionsprogramm der Internationalen
-    Konferenz über Bevölkerung und Entwicklung, der Aktionsplattform von Beijing und
-    den Ergebnisdokumenten ihrer Überprüfungskonferenzen vereinbart
-5.a:
-  title: Reformen durchführen, um Frauen die gleichen Rechte auf wirtschaftliche Ressourcen
-    sowie Zugang zu Grundeigentum und zur Verfügungsgewalt über Grund und Boden und
-    sonstige Vermögensformen, zu Finanzdienstleistungen, Erbschaften und natürlichen
-    Ressourcen zu verschaffen, im Einklang mit den nationalen Rechtsvorschriften
-5.b:
-  title: Die Nutzung von Grundlagentechnologien, insbesondere der Informations- und
-    Kommunikationstechnologien, verbessern, um die Selbstbestimmung der Frauen zu
-    fördern
-5.c:
-  title: Eine solide Politik und durchsetzbare Rechtsvorschriften zur Förderung der
-    Gleichstellung der Geschlechter und der Selbstbestimmung aller Frauen und Mädchen
-    auf allen Ebenen beschließen und verstärken
-'6.1':
-  title: Bis 2030 den allgemeinen und gerechten Zugang zu einwandfreiem und bezahlbarem
-    Trinkwasser für alle erreichen
-'6.2':
-  title: Bis 2030 den Zugang zu einer angemessenen und gerechten Sanitärversorgung
-    und Hygiene für alle erreichen und der Notdurftverrichtung im Freien ein Ende
-    setzen, unter besonderer Beachtung der Bedürfnisse von Frauen und Mädchen und
-    von Menschen in prekären Situationen
-'6.3':
-  title: Bis 2030 die Wasserqualität durch Verringerung der Verschmutzung, Beendigung
-    des Einbringens und Minimierung der Freisetzung gefährlicher Chemikalien und Stoffe,
-    Halbierung des Anteils unbehandelten Abwassers und eine beträchtliche Steigerung
-    der Wiederaufbereitung und gefahrlosen Wiederverwendung weltweit verbessern
-'6.4':
-  title: Bis 2030 die Effizienz der Wassernutzung in allen Sektoren wesentlich steigern
-    und eine nachhaltige Entnahme und Bereitstellung von Süßwasser gewährleisten,
-    um der Wasserknappheit zu begegnen und die Zahl der unter Wasserknappheit leidenden
-    Menschen erheblich zu verringern
-'6.5':
-  title: Bis 2030 auf allen Ebenen eine integrierte Bewirtschaftung der Wasserressourcen
-    umsetzen, gegebenenfalls auch mittels grenzüberschreitender Zusammenarbeit
-'6.6':
-  title: Bis 2020 wasserverbundene Ökosysteme schützen und wiederherstellen, darunter
-    Berge, Wälder, Feuchtgebiete, Flüsse, Grundwasserleiter und Seen
-6.a:
-  title: Bis 2030 die internationale Zusammenarbeit und die Unterstützung der Entwicklungsländer
-    beim Kapazitätsaufbau für Aktivitäten und Programme im Bereich der Wasser- und
-    Sanitärversorgung ausbauen, einschließlich der Wassersammlung und -speicherung,
-    Entsalzung, effizienten Wassernutzung, Abwasserbehandlung, Wiederaufbereitungs-
-    und Wiederverwendungstechnologien
-6.b:
-  title: Die Mitwirkung lokaler Gemeinwesen an der Verbesserung der Wasserbewirtschaftung
-    und der Sanitärversorgung unterstützen und verstärken
-'7.1':
-  title: Bis 2030 den allgemeinen Zugang zu bezahlbaren, verlässlichen und modernen
-    Energiedienstleistungen sichern
-'7.2':
-  title: Bis 2030 den Anteil erneuerbarer Energie am globalen Energiemix deutlich
-    erhöhen
-'7.3':
-  title: Bis 2030 die weltweite Steigerungsrate der Energieeffizienz verdoppeln
-7.a:
-  title: Bis 2030 die internationale Zusammenarbeit verstärken, um den Zugang zur
-    Forschung und Technologie im Bereich saubere Energie, namentlich erneuerbare Energie,
-    Energieeffizienz sowie fortschrittliche und saubere Technologien für fossile Brennstoffe,
-    zu erleichtern, und Investitionen in die Energieinfrastruktur und saubere Energietechnologien
-    fördern
-7.b:
-  title: Bis 2030 die Infrastruktur ausbauen und die Technologie modernisieren, um
-    in den Entwicklungsländern und insbesondere in den am wenigsten entwickelten Ländern,
-    den kleinen Inselentwicklungsländern und den Binnenentwicklungsländern im Einklang
-    mit ihren jeweiligen Unterstützungsprogrammen moderne und nachhaltige Energiedienstleistungen
-    für alle bereitzustellen
-'8.1':
-  title: Ein Pro-Kopf-Wirtschaftswachstum entsprechend den nationalen Gegebenheiten
-    und insbesondere ein jährliches Wachstum des Bruttoinlandsprodukts von mindestens
-    7 Prozent in den am wenigsten entwickelten Ländern aufrechterhalten
-'8.10':
-  title: Die Kapazitäten der nationalen Finanzinstitutionen stärken, um den Zugang
-    zu Bank-, Versicherungs- und Finanzdienstleistungen für alle zu begünstigen und
-    zu erweitern
-'8.2':
-  title: Eine höhere wirtschaftliche Produktivität durch Diversifizierung, technologische
-    Modernisierung und Innovation erreichen, einschließlich durch Konzentration auf
-    mit hoher Wertschöpfung verbundene und arbeitsintensive Sektoren
-'8.3':
-  title: Entwicklungsorientierte Politiken fördern, die produktive Tätigkeiten, die
-    Schaffung menschenwürdiger Arbeitsplätze, Unternehmertum, Kreativität und Innovation
-    unterstützen, und die Formalisierung und das Wachstum von Kleinst-, Klein- und
-    Mittelunternehmen unter anderem durch den Zugang zu Finanzdienstleistungen begünstigen
-'8.4':
-  title: Bis 2030 die weltweite Ressourceneffizienz in Konsum und Produktion Schritt
-    für Schritt verbessern und die Entkopplung von Wirtschaftswachstum und Umweltzerstörung
-    anstreben, im Einklang mit dem Zehnjahres-Programmrahmen für nachhaltige Konsum-
-    und Produktionsmuster, wobei die entwickelten Länder die Führung übernehmen
-'8.5':
-  title: Bis 2030 produktive Vollbeschäftigung und menschenwürdige Arbeit für alle
-    Frauen und Männer, einschließlich junger Menschen und Menschen mit Behinderungen,
-    sowie gleiches Entgelt für gleichwertige Arbeit erreichen
-'8.6':
-  title: Bis 2020 den Anteil junger Menschen, die ohne Beschäftigung sind und keine
-    Schul- oder Berufsausbildung durchlaufen, erheblich verringern
-'8.7':
-  title: Sofortige und wirksame Maßnahmen ergreifen, um Zwangsarbeit abzuschaffen,
-    moderne Sklaverei und Menschenhandel zu beenden und das Verbot und die Beseitigung
-    der schlimmsten Formen der Kinderarbeit, einschließlich der Einziehung und des
-    Einsatzes von Kindersoldaten, sicherstellen und bis 2025 jeder Form von Kinderarbeit
-    ein Ende setzen
-'8.8':
-  title: Die Arbeitsrechte schützen und sichere Arbeitsumgebungen für alle Arbeitnehmer,
-    einschließlich der Wanderarbeitnehmer, insbesondere der Wanderarbeitnehmerinnen,
-    und der Menschen in prekären Beschäftigungsverhältnissen, fördern
-'8.9':
-  title: Bis 2030 Politiken zur Förderung eines nachhaltigen Tourismus erarbeiten
-    und umsetzen, der Arbeitsplätze schafft und die lokale Kultur und lokale Produkte
-    fördert
-8.a:
-  title: Die im Rahmen der Handelshilfe gewährte Unterstützung für die Entwicklungsländer
-    und insbesondere die am wenigsten entwickelten Länder erhöhen, unter anderem durch
-    den Erweiterten integrierten Rahmenplan für handelsbezogene technische Hilfe für
-    die am wenigsten entwickelten Länder
-8.b:
-  title: Bis 2020 eine globale Strategie für Jugendbeschäftigung erarbeiten und auf
-    den Weg bringen und den Globalen Beschäftigungspakt der Internationalen Arbeitsorganisation
-    umsetzen
-'9.1':
-  title: Eine hochwertige, verlässliche, nachhaltige und widerstandsfähige Infrastruktur
-    aufbauen, einschließlich regionaler und grenzüberschreitender Infrastruktur, um
-    die wirtschaftliche Entwicklung und das menschliche Wohlergehen zu unterstützen,
-    und dabei den Schwerpunkt auf einen erschwinglichen und gleichberechtigten Zugang
-    für alle legen
-'9.2':
-  title: Eine breitenwirksame und nachhaltige Industrialisierung fördern und bis 2030
-    den Anteil der Industrie an der Beschäftigung und am Bruttoinlandsprodukt entsprechend
-    den nationalen Gegebenheiten erheblich steigern und den Anteil in den am wenigsten
-    entwickelten Ländern verdoppeln
-'9.3':
-  title: Insbesondere in den Entwicklungsländern den Zugang kleiner Industrie- und
-    anderer Unternehmen zu Finanzdienstleistungen, einschließlich bezahlbaren Krediten,
-    und ihre Einbindung in Wertschöpfungsketten und Märkte erhöhen
-'9.4':
-  title: Bis 2030 die Infrastruktur modernisieren und die Industrien nachrüsten, um
-    sie nachhaltig zu machen, mit effizienterem Ressourceneinsatz und unter vermehrter
-    Nutzung sauberer und umweltverträglicher Technologien und Industrieprozesse, wobei
-    alle Länder Maßnahmen entsprechend ihren jeweiligen Kapazitäten ergreifen
-'9.5':
-  title: Die wissenschaftliche Forschung verbessern und die technologischen Kapazitäten
-    der Industriesektoren in allen Ländern und insbesondere in den Entwicklungsländern
-    ausbauen und zu diesem Zweck bis 2030 unter anderem Innovationen fördern und die
-    Anzahl der im Bereich Forschung und Entwicklung tätigen Personen je 1 Million
-    Menschen sowie die öffentlichen und privaten Ausgaben für Forschung und Entwicklung
-    beträchtlich erhöhen
-9.a:
-  title: Die Entwicklung einer nachhaltigen und widerstandsfähigen Infrastruktur in
-    den Entwicklungsländern durch eine verstärkte finanzielle, technologische und
-    technische Unterstützung der afrikanischen Länder, der am wenigsten entwickelten
-    Länder, der Binnenentwicklungsländer und der kleinen Inselentwicklungsländer erleichtern
-9.b:
-  title: Die einheimische Technologieentwicklung, Forschung und Innovation in den
-    Entwicklungsländern unterstützen, einschließlich durch Sicherstellung eines förderlichen
-    politischen Umfelds, unter anderem für industrielle Diversifizierung und Wertschöpfung
-    im Rohstoffbereich
-9.c:
-  title: Den Zugang zur Informations- und Kommunikationstechnologie erheblich erweitern
-    sowie anstreben, in den am wenigsten entwickelten Ländern bis 2020 einen allgemeinen
-    und erschwinglichen Zugang zum Internet bereitzustellen
+1.1-title: Bis 2030 die extreme Armut - gegenwärtig definiert als der Anteil der Menschen,
+  die mit weniger als 1,25 Dollar pro Tag auskommen müssen - für alle Menschen überall
+  auf der Welt beseitigen
+1.2-title: Bis 2030 den Anteil der Männer, Frauen und Kinder jeden Alters, die in
+  Armut in all ihren Dimensionen nach der jeweiligen nationalen Definition leben,
+  mindestens um die Hälfte senken
+1.3-title: Den nationalen Gegebenheiten entsprechende Sozialschutzsysteme und -maßnahmen
+  für alle umsetzen, einschließlich eines Basisschutzes, und bis 2030 eine breite
+  Versorgung der Armen und Schwachen erreichen
+1.4-title: Bis 2030 sicherstellen, dass alle Männer und Frauen, insbesondere die Armen
+  und Schwachen, die gleichen Rechte auf wirtschaftliche Ressourcen sowie Zugang zu
+  grundlegenden Diensten, Grundeigentum und Verfügungsgewalt über Grund und Boden
+  und sonstigen Vermögensformen, Erbschaften, natürlichen Ressourcen, geeigneten neuen
+  Technologien und Finanzdienstleistungen einschließlich Mikrofinanzierung haben
+1.5-title: Bis 2030 die Widerstandsfähigkeit der Armen und der Menschen in prekären
+  Situationen erhöhen und ihre Exposition und Anfälligkeit gegenüber klimabedingten
+  Extremereignissen und anderen wirtschaftlichen, sozialen und ökologischen Schocks
+  und Katastrophen verringern
+1.a-title: Eine erhebliche Mobilisierung von Ressourcen aus einer Vielzahl von Quellen
+  gewährleisten, einschließlich durch verbesserte Entwicklungszusammenarbeit, um den
+  Entwicklungsländern und insbesondere den am wenigsten entwickelten Ländern ausreichende
+  und berechenbare Mittel für die Umsetzung von Programmen und Politiken zur Beendigung
+  der Armut in all ihren Dimensionen bereitzustellen
+1.b-title: Auf nationaler, regionaler und internationaler Ebene solide politische
+  Rahmen auf der Grundlage armutsorientierter und geschlechtersensibler Entwicklungsstrategien
+  schaffen, um beschleunigte Investitionen in Maßnahmen zur Beseitigung der Armut
+  zu unterstützen
+10.1-title: Bis 2030 nach und nach ein über dem nationalen Durchschnitt liegendes
+  Einkommenswachstum der ärmsten 40 Prozent der Bevölkerung erreichen und aufrechterhalten
+10.2-title: Bis 2030 alle Menschen unabhängig von Alter, Geschlecht, Behinderung,
+  Rasse, Ethnizität, Herkunft, Religion oder wirtschaftlichem oder sonstigem Status
+  zu Selbstbestimmung befähigen und ihre soziale, wirtschaftliche und politische Inklusion
+  fördern
+10.3-title: Chancengleichheit gewährleisten und Ungleichheit der Ergebnisse reduzieren,
+  namentlich durch die Abschaffung diskriminierender Gesetze, Politiken und Praktiken
+  und die Förderung geeigneter gesetzgeberischer, politischer und sonstiger Maßnahmen
+  in dieser Hinsicht
+10.4-title: Politische Maßnahmen beschließen, insbesondere fiskalische, lohnpolitische
+  und den Sozialschutz betreffende Maßnahmen, und schrittweise größere Gleichheit
+  erzielen
+10.5-title: Die Regulierung und Überwachung der globalen Finanzmärkte und -institutionen
+  verbessern und die Anwendung der einschlägigen Vorschriften verstärken
+10.6-title: Eine bessere Vertretung und verstärkte Mitsprache der Entwicklungsländer
+  bei der Entscheidungsfindung in den globalen internationalen Wirtschafts- und Finanzinstitutionen
+  sicherstellen, um die Wirksamkeit, Glaubwürdigkeit, Rechenschaftslegung und Legitimation
+  dieser Institutionen zu erhöhen
+10.7-title: Eine geordnete, sichere, reguläre und verantwortungsvolle Migration und
+  Mobilität von Menschen erleichtern, unter anderem durch die Anwendung einer planvollen
+  und gut gesteuerten Migrationspolitik
+10.a-title: Den Grundsatz der besonderen und differenzierten Behandlung der Entwicklungsländer,
+  insbesondere der am wenigsten entwickelten Länder, im Einklang mit den Übereinkünften
+  der Welthandelsorganisation anwenden
+10.b-title: Öffentliche Entwicklungshilfe und Finanzströme einschließlich ausländischer
+  Direktinvestitionen in die Staaten fördern, in denen der Bedarf am größten ist,
+  insbesondere in die am wenigsten entwickelten Länder, die afrikanischen Länder,
+  die kleinen Inselentwicklungsländer und die Binnenentwicklungsländer, im Einklang
+  mit ihren jeweiligen nationalen Plänen und Programmen
+10.c-title: Bis 2030 die Transaktionskosten für Heimatüberweisungen von Migranten
+  auf weniger als 3 Prozent senken und Überweisungskorridore mit Kosten von über 5
+  Prozent beseitigen
+11.1-title: Bis 2030 den Zugang zu angemessenem, sicherem und bezahlbarem Wohnraum
+  und zur Grundversorgung für alle sicherstellen und Slums sanieren
+11.2-title: Bis 2030 den Zugang zu sicheren, bezahlbaren, zugänglichen und nachhaltigen
+  Verkehrssystemen für alle ermöglichen und die Sicherheit im Straßenverkehr verbessern,
+  insbesondere durch den Ausbau des öffentlichen Verkehrs, mit besonderem Augenmerk
+  auf den Bedürfnissen von Menschen in prekären Situationen, Frauen, Kindern, Menschen
+  mit Behinderungen und älteren Menschen
+11.3-title: Bis 2030 die Verstädterung inklusiver und nachhaltiger gestalten und die
+  Kapazitäten für eine partizipatorische, integrierte und nachhaltige Siedlungsplanung
+  und -steuerung in allen Ländern verstärken
+11.4-title: Die Anstrengungen zum Schutz und zur Wahrung des Weltkultur- und -naturerbes
+  verstärken
+11.5-title: Bis 2030 die Zahl der durch Katastrophen, einschließlich Wasserkatastrophen,
+  bedingten Todesfälle und der davon betroffenen Menschen deutlich reduzieren und
+  die dadurch verursachten unmittelbaren wirtschaftlichen Verluste im Verhältnis zum
+  globalen Bruttoinlandsprodukt wesentlich verringern, mit Schwerpunkt auf dem Schutz
+  der Armen und von Menschen in prekären Situationen
+11.6-title: Bis 2030 die von den Städten ausgehende Umweltbelastung pro Kopf senken,
+  unter anderem mit besonderer Aufmerksamkeit auf der Luftqualität und der kommunalen
+  und sonstigen Abfallbehandlung
+11.7-title: Bis 2030 den allgemeinen Zugang zu sicheren, inklusiven und zugänglichen
+  Grünflächen und öffentlichen Räumen gewährleisten, insbesondere für Frauen und Kinder,
+  ältere Menschen und Menschen mit Behinderungen
+11.a-title: Durch eine verstärkte nationale und regionale Entwicklungsplanung positive
+  wirtschaftliche, soziale und ökologische Verbindungen zwischen städtischen, stadtnahen
+  und ländlichen Gebieten unterstützen
+11.b-title: Bis 2020 die Zahl der Städte und Siedlungen, die integrierte Politiken
+  und Pläne zur Förderung der Inklusion, der Ressourceneffizienz, der Abschwächung
+  des Klimawandels, der Klimaanpassung und der Widerstandsfähigkeit gegenüber Katastrophen
+  beschließen und umsetzen, wesentlich erhöhen und gemäß dem Sendai-Rahmen für Katastrophenvorsorge
+  2015-2030 ein ganzheitliches Katastrophenrisikomanagement auf allen Ebenen entwickeln
+  und umsetzen
+11.c-title: Die am wenigsten entwickelten Länder unter anderem durch finanzielle und
+  technische Hilfe beim Bau nachhaltiger und widerstandsfähiger Gebäude unter Nutzung
+  einheimischer Materialien unterstützen
+12.1-title: Den Zehnjahres-Programmrahmen für nachhaltige Konsum- und Produktionsmuster
+  umsetzen, wobei alle Länder, an der Spitze die entwickelten Länder, Maßnahmen ergreifen,
+  unter Berücksichtigung des Entwicklungsstands und der Kapazitäten der Entwicklungsländer
+12.2-title: Bis 2030 die nachhaltige Bewirtschaftung und effiziente Nutzung der natürlichen
+  Ressourcen erreichen
+12.3-title: Bis 2030 die weltweite Nahrungsmittelverschwendung pro Kopf auf Einzelhandels-
+  und Verbraucherebene halbieren und die entlang der Produktions- und Lieferkette
+  entstehenden Nahrungsmittelverluste einschließlich Nachernteverlusten verringern
+12.4-title: Bis 2020 einen umweltverträglichen Umgang mit Chemikalien und allen Abfällen
+  während ihres gesamten Lebenszyklus in Übereinstimmung mit den vereinbarten internationalen
+  Rahmenregelungen erreichen und ihre Freisetzung in Luft, Wasser und Boden erheblich
+  verringern, um ihre nachteiligen Auswirkungen auf die menschliche Gesundheit und
+  die Umwelt auf ein Mindestmaß zu beschränken
+12.5-title: Bis 2030 das Abfallaufkommen durch Vermeidung, Verminderung, Wiederverwertung
+  und Wiederverwendung deutlich verringern
+12.6-title: Die Unternehmen, insbesondere große und transnationale Unternehmen, dazu
+  ermutigen, nachhaltige Verfahren einzuführen und in ihre Berichterstattung Nachhaltigkeitsinformationen
+  aufzunehmen
+12.7-title: In der öffentlichen Beschaffung nachhaltige Verfahren fördern, im Einklang
+  mit den nationalen Politiken und Prioritäten
+12.8-title: Bis 2030 sicherstellen, dass die Menschen überall über einschlägige Informationen
+  und das Bewusstsein für nachhaltige Entwicklung und eine Lebensweise in Harmonie
+  mit der Natur verfügen
+12.a-title: Die Entwicklungsländer bei der Stärkung ihrer wissenschaftlichen und technologischen
+  Kapazitäten im Hinblick auf den Übergang zu nachhaltigeren Konsum- und Produktionsmustern
+  unterstützen
+12.b-title: Instrumente zur Beobachtung der Auswirkungen eines nachhaltigen Tourismus,
+  der Arbeitsplätze schafft und die lokale Kultur und lokale Produkte fördert, auf
+  die nachhaltige Entwicklung entwickeln und anwenden
+12.c-title: Die ineffiziente Subventionierung fossiler Brennstoffe, die zu verschwenderischem
+  Verbrauch verleitet, durch Beseitigung von Marktverzerrungen entsprechend den nationalen
+  Gegebenheiten rationalisieren, unter anderem durch eine Umstrukturierung der Besteuerung
+  und die allmähliche Abschaffung dieser schädlichen Subventionen, um ihren Umweltauswirkungen
+  Rechnung zu tragen, wobei die besonderen Bedürfnisse und Gegebenheiten der Entwicklungsländer
+  in vollem Umfang berücksichtigt und die möglichen nachteiligen Auswirkungen auf
+  ihre Entwicklung in einer die Armen und die betroffenen Gemeinwesen schützenden
+  Weise so gering wie möglich gehalten werden
+13.1-title: Die Widerstandskraft und die Anpassungsfähigkeit gegenüber klimabedingten
+  Gefahren und Naturkatastrophen in allen Ländern stärken
+13.2-title: Klimaschutzmaßnahmen in die nationalen Politiken, Strategien und Planungen
+  einbeziehen
+13.3-title: Die Aufklärung und Sensibilisierung sowie die personellen und institutionellen
+  Kapazitäten im Bereich der Abschwächung des Klimawandels, der Klimaanpassung, der
+  Reduzierung der Klimaauswirkungen sowie der Frühwarnung verbessern
+13.a-title: Die Verpflichtung erfüllen, die von den Vertragsparteien des Rahmenübereinkommens
+  der Vereinten Nationen über Klimaänderungen, die entwickelte Länder sind, übernommen
+  wurde, bis 2020 gemeinsam jährlich 100 Milliarden Dollar aus allen Quellen aufzubringen,
+  um den Bedürfnissen der Entwicklungsländer im Kontext sinnvoller Klimaschutzmaßnahmen
+  und einer transparenten Umsetzung zu entsprechen, und den Grünen Klimafonds vollständig
+  zu operationalisieren, indem er schnellstmöglich mit den erforderlichen Finanzmitteln
+  ausgestattet wird
+13.b-title: Mechanismen zum Ausbau effektiver Planungs- und Managementkapazitäten
+  im Bereich des Klimawandels in den am wenigsten entwickelten Ländern und kleinen
+  Inselentwicklungsländern fördern, unter anderem mit gezielter Ausrichtung auf Frauen,
+  junge Menschen sowie lokale und marginalisierte Gemeinwesen
+14.1-title: Bis 2025 alle Arten der Meeresverschmutzung, insbesondere durch vom Lande
+  ausgehende Tätigkeiten und namentlich Meeresmüll und Nährstoffbelastung, verhüten
+  und erheblich verringern
+14.2-title: Bis 2020 die Meeres- und Küstenökosysteme nachhaltig bewirtschaften und
+  schützen, um unter anderem durch Stärkung ihrer Resilienz erhebliche nachteilige
+  Auswirkungen zu vermeiden, und Maßnahmen zu ihrer Wiederherstellung ergreifen, damit
+  die Meere wieder gesund und produktiv werden
+14.3-title: Die Versauerung der Ozeane auf ein Mindestmaß reduzieren und ihre Auswirkungen
+  bekämpfen, unter anderem durch eine verstärkte wissenschaftliche Zusammenarbeit
+  auf allen Ebenen
+14.4-title: Bis 2020 die Fangtätigkeit wirksam regeln und die Überfischung, die illegale,
+  ungemeldete und unregulierte Fischerei und zerstörerische Fangpraktiken beenden
+  und wissenschaftlich fundierte Bewirtschaftungspläne umsetzen, um die Fischbestände
+  in kürzestmöglicher Zeit mindestens auf einen Stand zurückzuführen, der den höchstmöglichen
+  Dauerertrag unter Berücksichtigung ihrer biologischen Merkmale sichert
+14.5-title: Bis 2020 mindestens 10 Prozent der Küsten- und Meeresgebiete im Einklang
+  mit dem nationalen Recht und dem Völkerrecht und auf der Grundlage der besten verfügbaren
+  wissenschaftlichen Informationen erhalten
+14.6-title: Bis 2020 bestimmte Formen der Fischereisubventionen untersagen, die zu
+  Überkapazitäten und Überfischung beitragen, Subventionen abschaffen, die zu illegaler,
+  ungemeldeter und unregulierter Fischerei beitragen, und keine neuen derartigen Subventionen
+  einführen, in Anerkennung dessen, dass eine geeignete und wirksame besondere und
+  differenzierte Behandlung der Entwicklungsländer und der am wenigsten entwickelten
+  Länder einen untrennbaren Bestandteil der im Rahmen der Welthandelsorganisation
+  geführten Verhandlungen über Fischereisubventionen bilden sollte
+14.7-title: Bis 2030 die sich aus der nachhaltigen Nutzung der Meeresressourcen ergebenden
+  wirtschaftlichen Vorteile für die kleinen Inselentwicklungsländer und die am wenigsten
+  entwickelten Länder erhöhen, namentlich durch nachhaltiges Management der Fischerei,
+  der Aquakultur und des Tourismus
+14.a-title: Die wissenschaftlichen Kenntnisse vertiefen, die Forschungskapazitäten
+  ausbauen und Meerestechnologien weitergeben, unter Berücksichtigung der Kriterien
+  und Leitlinien der Zwischenstaatlichen Ozeanographischen Kommission für die Weitergabe
+  von Meerestechnologie, um die Gesundheit der Ozeane zu verbessern und den Beitrag
+  der biologischen Vielfalt der Meere zur Entwicklung der Entwicklungsländer, insbesondere
+  der kleinen Inselentwicklungsländer und der am wenigsten entwickelten Länder, zu
+  verstärken
+14.b-title: Den Zugang der handwerklichen Kleinfischer zu den Meeresressourcen und
+  Märkten gewährleisten
+14.c-title: "Die Erhaltung und nachhaltige Nutzung der Ozeane und ihrer Ressourcen\
+  \ verbessern und zu diesem Zweck das Völkerrecht umsetzen, wie es im Seerechtsübereinkommen\
+  \ der Vereinten Nationen niedergelegt ist, das den rechtlichen Rahmen für die Erhaltung\
+  \ und nachhaltige Nutzung der Ozeane und ihrer Ressourcen vorgibt, worauf in Ziffer\
+  \ 158 des Dokuments \x84Die Zukunft, die wir wollen\x93 hingewiesen wird"
+15.1-title: Bis 2020 im Einklang mit den Verpflichtungen aus internationalen Übereinkünften
+  die Erhaltung, Wiederherstellung und nachhaltige Nutzung der Land- und Binnensüßwasser-
+  Ökosysteme und ihrer Dienstleistungen, insbesondere der Wälder, der Feuchtgebiete,
+  der Berge und der Trockengebiete, gewährleisten
+15.2-title: Bis 2020 die nachhaltige Bewirtschaftung aller Waldarten fördern, die
+  Entwaldung beenden, geschädigte Wälder wiederherstellen und die Aufforstung und
+  Wiederaufforstung weltweit beträchtlich erhöhen
+15.3-title: Bis 2030 die Wüstenbildung bekämpfen, die geschädigten Flächen und Böden
+  einschließlich der von Wüstenbildung, Dürre und Überschwemmungen betroffenen Flächen
+  sanieren und eine Welt anstreben, in der die Landverödung neutralisiert wird
+15.4-title: Bis 2030 die Erhaltung der Bergökosysteme einschließlich ihrer biologischen
+  Vielfalt sicherstellen, um ihre Fähigkeit zur Erbringung wesentlichen Nutzens für
+  die nachhaltige Entwicklung zu stärken
+15.5-title: Umgehende und bedeutende Maßnahmen ergreifen, um die Verschlechterung
+  der natürlichen Lebensräume zu verringern, dem Verlust der biologischen Vielfalt
+  ein Ende zu setzen und bis 2020 die bedrohten Arten zu schützen und ihr Aussterben
+  zu verhindern
+15.6-title: Die ausgewogene und gerechte Aufteilung der sich aus der Nutzung der genetischen
+  Ressourcen ergebenden Vorteile und den angemessenen Zugang zu diesen Ressourcen
+  fördern, wie auf internationaler Ebene vereinbart
+15.7-title: Dringend Maßnahmen ergreifen, um der Wilderei und dem Handel mit geschützten
+  Pflanzen- und Tierarten ein Ende zu setzen und dem Problem des Angebots illegaler
+  Produkte aus wildlebenden Pflanzen und Tieren und der Nachfrage danach zu begegnen
+15.8-title: Bis 2020 Maßnahmen einführen, um das Einbringen invasiver gebietsfremder
+  Arten zu verhindern, ihre Auswirkungen auf die Land- und Wasserökosysteme deutlich
+  zu reduzieren und die prioritären Arten zu kontrollieren oder zu beseitigen
+15.9-title: Bis 2020 Ökosystem- und Biodiversitätswerte in die nationalen und lokalen
+  Planungen, Entwicklungsprozesse, Armutsbekämpfungsstrategien und Gesamtrechnungssysteme
+  einbeziehen
+15.a-title: Finanzielle Mittel aus allen Quellen für die Erhaltung und nachhaltige
+  Nutzung der biologischen Vielfalt und der Ökosysteme aufbringen und deutlich erhöhen
+15.b-title: Erhebliche Mittel aus allen Quellen und auf allen Ebenen für die Finanzierung
+  einer nachhaltigen Bewirtschaftung der Wälder aufbringen und den Entwicklungsländern
+  geeignete Anreize für den vermehrten Einsatz dieser Bewirtschaftungsform bieten,
+  namentlich zum Zweck der Walderhaltung und Wiederaufforstung
+15.c-title: Die weltweite Unterstützung von Maßnahmen zur Bekämpfung der Wilderei
+  und des Handels mit geschützten Arten verstärken, unter anderem durch die Stärkung
+  der Fähigkeit lokaler Gemeinwesen, Möglichkeiten einer nachhaltigen Existenzsicherung
+  zu nutzen
+16.1-title: Alle Formen der Gewalt und die gewaltbedingte Sterblichkeit überall deutlich
+  verringern
+16.10-title: Den öffentlichen Zugang zu Informationen gewährleisten und die Grundfreiheiten
+  schützen, im Einklang mit den nationalen Rechtsvorschriften und völkerrechtlichen
+  Übereinkünften
+16.2-title: Missbrauch und Ausbeutung von Kindern, den Kinderhandel, Folter und alle
+  Formen von Gewalt gegen Kinder beenden
+16.3-title: Die Rechtsstaatlichkeit auf nationaler und internationaler Ebene fördern
+  und den gleichberechtigten Zugang aller zur Justiz gewährleisten
+16.4-title: Bis 2030 illegale Finanz- und Waffenströme deutlich verringern, die Wiedererlangung
+  und Rückgabe gestohlener Vermögenswerte verstärken und alle Formen der organisierten
+  Kriminalität bekämpfen
+16.5-title: Korruption und Bestechung in allen ihren Formen erheblich reduzieren
+16.6-title: Leistungsfähige, rechenschaftspflichtige und transparente Institutionen
+  auf allen Ebenen aufbauen
+16.7-title: Dafür sorgen, dass die Entscheidungsfindung auf allen Ebenen bedarfsorientiert,
+  inklusiv, partizipatorisch und repräsentativ ist
+16.8-title: Die Teilhabe der Entwicklungsländer an den globalen Lenkungsinstitutionen
+  erweitern und verstärken
+16.9-title: Bis 2030 insbesondere durch die Registrierung der Geburten dafür sorgen,
+  dass alle Menschen eine rechtliche Identität haben
+16.a-title: Die zuständigen nationalen Institutionen namentlich durch internationale
+  Zusammenarbeit beim Kapazitätsaufbau auf allen Ebenen zur Verhütung von Gewalt und
+  zur Bekämpfung von Terrorismus und Kriminalität unterstützen, insbesondere in den
+  Entwicklungsländern
+16.b-title: Nichtdiskriminierende Rechtsvorschriften und Politiken zugunsten einer
+  nachhaltigen Entwicklung fördern und durchsetzen
+17.1-title: Die Mobilisierung einheimischer Ressourcen verstärken, einschließlich
+  durch internationale Unterstützung für die Entwicklungsländer, um die nationalen
+  Kapazitäten zur Erhebung von Steuern und anderen Abgaben zu verbessern
+17.10-title: Ein universales, regelgestütztes, offenes, nichtdiskriminierendes und
+  gerechtes multilaterales Handelssystem unter dem Dach der Welthandelsorganisation
+  fördern, insbesondere durch den Abschluss der Verhandlungen im Rahmen ihrer Entwicklungsagenda
+  von Doha
+17.11-title: Die Exporte der Entwicklungsländer deutlich erhöhen, insbesondere mit
+  Blick darauf, den Anteil der am wenigsten entwickelten Länder an den weltweiten
+  Exporten bis 2020 zu verdoppeln
+17.12-title: Die rasche Umsetzung des zoll- und kontingentfreien Marktzugangs auf
+  dauerhafter Grundlage für alle am wenigsten entwickelten Länder im Einklang mit
+  den Beschlüssen der Welthandelsorganisation erreichen, unter anderem indem sichergestellt
+  wird, dass die für Importe aus den am wenigsten entwickelten Ländern geltenden präferenziellen
+  Ursprungsregeln transparent und einfach sind und zur Erleichterung des Marktzugangs
+  beitragen
+17.13-title: Die globale makroökonomische Stabilität verbessern, namentlich durch
+  Politikkoordinierung und Politikkohärenz
+17.14-title: Die Politikkohärenz zugunsten nachhaltiger Entwicklung verbessern
+17.15-title: Den politischen Spielraum und die Führungsrolle jedes Landes bei der
+  Festlegung und Umsetzung von Politiken zur Armutsbeseitigung und für nachhaltige
+  Entwicklung respektieren
+17.16-title: Die Globale Partnerschaft für nachhaltige Entwicklung ausbauen, ergänzt
+  durch Multi-Akteur-Partnerschaften zur Mobilisierung und zum Austausch von Wissen,
+  Fachkenntnissen, Technologie und finanziellen Ressourcen, um die Erreichung der
+  Ziele für nachhaltige Entwicklung in allen Ländern und insbesondere in den Entwicklungsländern
+  zu unterstützen
+17.17-title: Die Bildung wirksamer öffentlicher, öffentlich-privater und zivilgesellschaftlicher
+  Partnerschaften aufbauend auf den Erfahrungen und Mittelbeschaffungsstrategien bestehender
+  Partnerschaften unterstützen und fördern
+17.18-title: Bis 2020 die Unterstützung des Kapazitätsaufbaus für die Entwicklungsländer
+  und namentlich die am wenigsten entwickelten Länder und die kleinen Inselentwicklungsländer
+  erhöhen, mit dem Ziel, über erheblich mehr hochwertige, aktuelle und verlässliche
+  Daten zu verfügen, die nach Einkommen, Geschlecht, Alter, Rasse, Ethnizität, Migrationsstatus,
+  Behinderung, geografischer Lage und sonstigen im nationalen Kontext relevanten Merkmalen
+  aufgeschlüsselt sind
+17.19-title: Bis 2030 auf den bestehenden Initiativen aufbauen, um Fortschrittsmaße
+  für nachhaltige Entwicklung zu erarbeiten, die das Bruttoinlandsprodukt ergänzen,
+  und den Aufbau der statistischen Kapazitäten der Entwicklungsländer unterstützen
+17.2-title: Sicherstellen, dass die entwickelten Länder ihre Zusagen im Bereich der
+  öffentlichen Entwicklungshilfe voll einhalten, einschließlich der von vielen entwickelten
+  Ländern eingegangenen Verpflichtung, die Zielvorgabe von 0,7 Prozent ihres Bruttonationaleinkommens
+  für öffentliche Entwicklungshilfe zugunsten der Entwicklungsländer und 0,15 bis
+  0,20 Prozent zugunsten der am wenigsten entwickelten Länder zu erreichen; den Gebern
+  öffentlicher Entwicklungshilfe wird nahegelegt, die Bereitstellung von mindestens
+  0,20&nbsp;Prozent ihres Bruttonationaleinkommens zugunsten der am wenigsten entwickelten
+  Länder als Zielsetzung zu erwägen
+17.3-title: Zusätzliche finanzielle Mittel aus verschiedenen Quellen für die Entwicklungsländer
+  mobilisieren
+17.4-title: Den Entwicklungsländern dabei behilflich sein, durch eine koordinierte
+  Politik zur Förderung der Schuldenfinanzierung, der Entschuldung beziehungsweise
+  der Umschuldung die langfristige Tragfähigkeit der Verschuldung zu erreichen, und
+  das Problem der Auslandsverschuldung hochverschuldeter armer Länder angehen, um
+  die Überschuldung zu verringern
+17.5-title: Investitionsförderungssysteme für die am wenigsten entwickelten Länder
+  beschließen und umsetzen
+17.6-title: Die regionale und internationale Nord-Süd- und Süd-Süd-Zusammenarbeit
+  und Dreieckskooperation im Bereich Wissenschaft, Technologie und Innovation und
+  den Zugang dazu verbessern und den Austausch von Wissen zu einvernehmlich festgelegten
+  Bedingungen verstärken, unter anderem durch eine bessere Abstimmung zwischen den
+  vorhandenen Mechanismen, insbesondere auf Ebene der Vereinten Nationen, und durch
+  einen globalen Mechanismus zur Technologieförderung
+17.7-title: Die Entwicklung, den Transfer, die Verbreitung und die Diffusion von umweltverträglichen
+  Technologien an die Entwicklungsländer zu gegenseitig vereinbarten günstigen Bedingungen,
+  einschließlich Konzessions- und Vorzugsbedingungen, fördern
+17.8-title: Die Technologiebank und den Mechanismus zum Kapazitätsaufbau für Wissenschaft,
+  Technologie und Innovation für die am wenigsten entwickelten Länder bis 2017 vollständig
+  operationalisieren und die Nutzung von Grundlagentechnologien, insbesondere der
+  Informations- und Kommunikationstechnologien, verbessern
+17.9-title: Die internationale Unterstützung für die Durchführung eines effektiven
+  und gezielten Kapazitätsaufbaus in den Entwicklungsländern verstärken, um die nationalen
+  Pläne zur Umsetzung aller Ziele für nachhaltige Entwicklung zu unterstützen, namentlich
+  im Rahmen der Nord-Süd- und Süd-Süd-Zusammenarbeit und der Dreieckskooperation
+2.1-title: Bis 2030 den Hunger beenden und sicherstellen, dass alle Menschen, insbesondere
+  die Armen und Menschen in prekären Situationen, einschließlich Kleinkindern, ganzjährig
+  Zugang zu sicheren, nährstoffreichen und ausreichenden Nahrungsmitteln haben
+2.2-title: Bis 2030 alle Formen der Mangelernährung beenden, einschließlich durch
+  Erreichung der international vereinbarten Zielvorgaben in Bezug auf Wachstumshemmung
+  und Auszehrung bei Kindern unter 5&nbsp;Jahren bis 2025, und den Ernährungsbedürfnissen
+  von heranwachsenden Mädchen, schwangeren und stillenden Frauen und älteren Menschen
+  Rechnung tragen
+2.3-title: Bis 2030 die landwirtschaftliche Produktivität und die Einkommen von kleinen
+  Nahrungsmittel-produzenten, insbesondere von Frauen, Angehörigen indigener Völker,
+  landwirtschaftlichen Familienbetrieben, Weidetierhaltern und Fischern, verdoppeln,
+  unter anderem durch den sicheren und gleichberechtigten Zugang zu Grund und Boden,
+  anderen Produktionsressourcen und Betriebsmitteln, Wissen, Finanzdienstleistungen,
+  Märkten sowie Möglichkeiten für Wertschöpfung und außerlandwirtschaftliche Beschäftigung
+2.4-title: Bis 2030 die Nachhaltigkeit der Systeme der Nahrungsmittelproduktion sicherstellen
+  und  resiliente landwirtschaftliche Methoden anwenden, die die Produktivität und
+  den Ertrag steigern, zur Erhaltung der Ökosysteme beitragen, die Anpassungsfähigkeit
+  an Klimaänderungen, extreme Wetterereignisse, Dürren, Überschwemmungen und andere
+  Katastrophen erhöhen und die Flächen- und Bodenqualität schrittweise verbessern
+2.5-title: Bis 2020 die genetische Vielfalt von Saatgut, Kulturpflanzen sowie Nutz-
+  und Haustieren und ihren wildlebenden Artverwandten bewahren, unter anderem durch
+  gut verwaltete und diversifizierte Saatgut- und Pflanzenbanken auf nationaler, regionaler
+  und internationaler Ebene, und den Zugang zu den Vorteilen aus der Nutzung der genetischen
+  Ressourcen und des damit verbundenen traditionellen Wissens sowie die ausgewogene
+  und gerechte Aufteilung dieser Vorteile fördern, wie auf internationaler Ebene vereinbart
+2.a-title: Die Investitionen in die ländliche Infrastruktur, die Agrarforschung und
+  landwirtschaftliche Beratungsdienste, die Technologieentwicklung sowie Genbanken
+  für Pflanzen und Nutztiere erhöhen, unter anderem durch verstärkte internationale
+  Zusammenarbeit, um die landwirtschaftliche Produktionskapazität in den Entwicklungsländern
+  und insbesondere den am wenigsten entwickelten Ländern zu verbessern
+2.b-title: Handelsbeschränkungen und -verzerrungen auf den globalen Agrarmärkten korrigieren
+  und verhindern, unter anderem durch die parallele Abschaffung aller Formen von Agrarexportsubventionen
+  und aller Exportmaßnahmen mit gleicher Wirkung im Einklang mit dem Mandat der Doha-Entwicklungsrunde
+2.c-title: Maßnahmen zur Gewährleistung des reibungslosen Funktionierens der Märkte
+  für Nahrungsmittelrohstoffe und ihre Derivate ergreifen und den raschen Zugang zu
+  Marktinformationen, unter anderem über Nahrungsmittelreserven, erleichtern, um zur
+  Begrenzung der extremen Schwankungen der Nahrungsmittelpreise beizutragen
+3.1-title: Bis 2030 die weltweite Müttersterblichkeit auf unter 70 je 100&nbsp;000
+  Lebendgeburten senken
+3.2-title: Bis 2030 den vermeidbaren Todesfällen bei Neugeborenen und Kindern unter
+  5 Jahren ein Ende setzen, mit dem von allen Ländern zu verfolgenden Ziel, die Sterblichkeit
+  bei Neugeborenen mindestens auf 12 je 1&nbsp;000 Lebendgeburten und bei Kindern
+  unter 5 Jahren mindestens auf 25 je 1&nbsp;000 Lebendgeburten zu senken
+3.3-title: Bis 2030 die Aids-, Tuberkulose- und Malariaepidemien und die vernachlässigten
+  Tropenkrankheiten beseitigen und Hepatitis, durch Wasser übertragene Krankheiten
+  und andere übertragbare Krankheiten bekämpfen
+3.4-title: Bis 2030 die Frühsterblichkeit aufgrund von nichtübertragbaren Krankheiten
+  durch Prävention und Behandlung um ein Drittel senken und die psychische Gesundheit
+  und das Wohlergehen fördern
+3.5-title: Die Prävention und Behandlung des Substanzmissbrauchs, namentlich des Suchtstoffmissbrauchs
+  und des schädlichen Gebrauchs von Alkohol, verstärken
+3.6-title: Bis 2020 die Zahl der Todesfälle und Verletzungen infolge von Verkehrsunfällen
+  weltweit halbieren
+3.7-title: Bis 2030 den allgemeinen Zugang zu sexual- und reproduktionsmedizinischer
+  Versorgung, einschließlich Familienplanung, Information und Aufklärung, und die
+  Einbeziehung der reproduktiven Gesundheit in nationale Strategien und Programme
+  gewährleisten
+3.8-title: Die allgemeine Gesundheitsversorgung, einschließlich der Absicherung gegen
+  finanzielle Risiken, den Zugang zu hochwertigen grundlegenden Gesundheitsdiensten
+  und den Zugang zu sicheren, wirksamen, hochwertigen und bezahlbaren unentbehrlichen
+  Arzneimitteln und Impfstoffen für alle erreichen
+3.9-title: Bis 2030 die Zahl der Todesfälle und Erkrankungen aufgrund gefährlicher
+  Chemikalien und der Verschmutzung und Verunreinigung von Luft, Wasser und Boden
+  erheblich verringern
+3.a-title: Die Durchführung des Rahmenübereinkommens der Weltgesundheitsorganisation
+  zur Eindämmung des Tabakgebrauchs in allen Ländern nach Bedarf stärken
+3.b-title: Forschung und Entwicklung zu Impfstoffen und Medikamenten für übertragbare
+  und nichtübertragbare Krankheiten, von denen hauptsächlich Entwicklungsländer betroffen
+  sind, unterstützen, den Zugang zu bezahlbaren unentbehrlichen Arzneimitteln und
+  Impfstoffen gewährleisten, im Einklang mit der Erklärung von Doha über das TRIPS-Übereinkommen
+  und die öffentliche Gesundheit, die das Recht der Entwicklungsländer bekräftigt,
+  die Bestimmungen in dem Übereinkommen über handelsbezogene Aspekte der Rechte des
+  geistigen Eigentums über Flexibilitäten zum Schutz der öffentlichen Gesundheit voll
+  auszuschöpfen, und insbesondere den Zugang zu Medikamenten für alle zu gewährleisten
+3.c-title: Die Gesundheitsfinanzierung und die Rekrutierung, Aus- und Weiterbildung
+  und Bindung von Gesundheitsfachkräften in den Entwicklungsländern und insbesondere
+  in den am wenigsten entwickelten Ländern und den kleinen Inselentwicklungsländern
+  deutlich erhöhen
+3.d-title: Die Kapazitäten aller Länder, insbesondere der Entwicklungsländer, in den
+  Bereichen Frühwarnung, Risikominderung und Management nationaler und globaler Gesundheitsrisiken
+  stärken
+4.1-title: Bis 2030 sicherstellen, dass alle Mädchen und Jungen gleichberechtigt eine
+  kostenlose und hochwertige Grund- und Sekundarschulbildung abschließen, die zu brauchbaren
+  und effektiven Lernergebnissen führt
+4.2-title: Bis 2030 sicherstellen, dass alle Mädchen und Jungen Zugang zu hochwertiger
+  frühkindlicher Erziehung, Betreuung und Vorschulbildung erhalten, damit sie auf
+  die Grundschule vorbereitet sind
+4.3-title: Bis 2030 den gleichberechtigten Zugang aller Frauen und Männer zu einer
+  erschwinglichen und hochwertigen fachlichen, beruflichen und tertiären Bildung einschließlich
+  universitärer Bildung gewährleisten
+4.4-title: Bis 2030 die Zahl der Jugendlichen und Erwachsenen wesentlich erhöhen,
+  die über die entsprechenden Qualifikationen einschließlich fachlicher und beruflicher
+  Qualifikationen für eine Beschäftigung, eine menschenwürdige Arbeit und Unternehmertum
+  verfügen
+4.5-title: Bis 2030 geschlechtsspezifische Disparitäten in der Bildung beseitigen
+  und den gleichberechtigen Zugang der Schwachen in der Gesellschaft, namentlich von
+  Menschen mit Behinderungen, Angehörigen indigener Völker und Kindern in prekären
+  Situationen, zu allen Bildungs- und Ausbildungsebenen gewährleisten
+4.6-title: Bis 2030 sicherstellen, dass alle Jugendlichen und ein erheblicher Anteil
+  der männlichen und weiblichen Erwachsenen lesen, schreiben und rechnen lernen
+4.7-title: Bis 2030 sicherstellen, dass alle Lernenden die notwendigen Kenntnisse
+  und Qualifikationen zur Förderung nachhaltiger Entwicklung erwerben, unter anderem
+  durch Bildung für nachhaltige Entwicklung und nachhaltige Lebensweisen, Menschenrechte,
+  Geschlechtergleichstellung, eine Kultur des Friedens und der Gewaltlosigkeit, Weltbürgerschaft
+  und die Wertschätzung kultureller Vielfalt und des Beitrags der Kultur zu nachhaltiger
+  Entwicklung
+4.a-title: Bildungseinrichtungen bauen und ausbauen, die kinder-, behinderten- und
+  geschlechtergerecht sind und eine sichere, gewaltfreie, inklusive und effektive
+  Lernumgebung für alle bieten
+4.b-title: Bis 2020 weltweit die Zahl der verfügbaren Stipendien für Entwicklungsländer,
+  insbesondere für die am wenigsten entwickelten Länder, die kleinen Inselentwicklungsländer
+  und die afrikanischen Länder, zum Besuch einer Hochschule, einschließlich zur Berufsbildung
+  und zu Informations- und Kommunikationstechnik-, Technik-, Ingenieurs- und Wissenschaftsprogrammen,
+  in entwickelten Ländern und in anderen Entwicklungsländern wesentlich erhöhen
+4.c-title: Bis 2030 das Angebot an qualifizierten Lehrkräften unter anderem durch
+  internationale Zusammenarbeit im Bereich der Lehrerausbildung in den Entwicklungsländern
+  und insbesondere in den am wenigsten entwickelten Ländern und kleinen Inselentwicklungsländern
+  wesentlich erhöhen
+5.1-title: Alle Formen der Diskriminierung von Frauen und Mädchen überall auf der
+  Welt beenden
+5.2-title: Alle Formen von Gewalt gegen alle Frauen und Mädchen im öffentlichen und
+  im privaten Bereich einschließlich des Menschenhandels und sexueller und anderer
+  Formen der Ausbeutung beseitigen
+5.3-title: Alle schädlichen Praktiken wie Kinderheirat, Frühverheiratung und Zwangsheirat
+  sowie die Genitalverstümmelung bei Frauen und Mädchen beseitigen
+5.4-title: Unbezahlte Pflege- und Hausarbeit durch die Bereitstellung öffentlicher
+  Dienstleistungen und Infrastrukturen, Sozialschutzmaßnahmen und die Förderung geteilter
+  Verantwortung innerhalb des Haushalts und der Familie entsprechend den nationalen
+  Gegebenheiten anerkennen und wertschätzen
+5.5-title: Die volle und wirksame Teilhabe von Frauen und ihre Chancengleichheit bei
+  der Übernahme von Führungsrollen auf allen Ebenen der Entscheidungsfindung im politischen,
+  wirtschaftlichen und öffentlichen Leben sicherstellen
+5.6-title: Den allgemeinen Zugang zu sexueller und reproduktiver Gesundheit und reproduktiven
+  Rechten gewährleisten, wie im Einklang mit dem Aktionsprogramm der Internationalen
+  Konferenz über Bevölkerung und Entwicklung, der Aktionsplattform von Beijing und
+  den Ergebnisdokumenten ihrer Überprüfungskonferenzen vereinbart
+5.a-title: Reformen durchführen, um Frauen die gleichen Rechte auf wirtschaftliche
+  Ressourcen sowie Zugang zu Grundeigentum und zur Verfügungsgewalt über Grund und
+  Boden und sonstige Vermögensformen, zu Finanzdienstleistungen, Erbschaften und natürlichen
+  Ressourcen zu verschaffen, im Einklang mit den nationalen Rechtsvorschriften
+5.b-title: Die Nutzung von Grundlagentechnologien, insbesondere der Informations-
+  und Kommunikationstechnologien, verbessern, um die Selbstbestimmung der Frauen zu
+  fördern
+5.c-title: Eine solide Politik und durchsetzbare Rechtsvorschriften zur Förderung
+  der Gleichstellung der Geschlechter und der Selbstbestimmung aller Frauen und Mädchen
+  auf allen Ebenen beschließen und verstärken
+6.1-title: Bis 2030 den allgemeinen und gerechten Zugang zu einwandfreiem und bezahlbarem
+  Trinkwasser für alle erreichen
+6.2-title: Bis 2030 den Zugang zu einer angemessenen und gerechten Sanitärversorgung
+  und Hygiene für alle erreichen und der Notdurftverrichtung im Freien ein Ende setzen,
+  unter besonderer Beachtung der Bedürfnisse von Frauen und Mädchen und von Menschen
+  in prekären Situationen
+6.3-title: Bis 2030 die Wasserqualität durch Verringerung der Verschmutzung, Beendigung
+  des Einbringens und Minimierung der Freisetzung gefährlicher Chemikalien und Stoffe,
+  Halbierung des Anteils unbehandelten Abwassers und eine beträchtliche Steigerung
+  der Wiederaufbereitung und gefahrlosen Wiederverwendung weltweit verbessern
+6.4-title: Bis 2030 die Effizienz der Wassernutzung in allen Sektoren wesentlich steigern
+  und eine nachhaltige Entnahme und Bereitstellung von Süßwasser gewährleisten, um
+  der Wasserknappheit zu begegnen und die Zahl der unter Wasserknappheit leidenden
+  Menschen erheblich zu verringern
+6.5-title: Bis 2030 auf allen Ebenen eine integrierte Bewirtschaftung der Wasserressourcen
+  umsetzen, gegebenenfalls auch mittels grenzüberschreitender Zusammenarbeit
+6.6-title: Bis 2020 wasserverbundene Ökosysteme schützen und wiederherstellen, darunter
+  Berge, Wälder, Feuchtgebiete, Flüsse, Grundwasserleiter und Seen
+6.a-title: Bis 2030 die internationale Zusammenarbeit und die Unterstützung der Entwicklungsländer
+  beim Kapazitätsaufbau für Aktivitäten und Programme im Bereich der Wasser- und Sanitärversorgung
+  ausbauen, einschließlich der Wassersammlung und -speicherung, Entsalzung, effizienten
+  Wassernutzung, Abwasserbehandlung, Wiederaufbereitungs- und Wiederverwendungstechnologien
+6.b-title: Die Mitwirkung lokaler Gemeinwesen an der Verbesserung der Wasserbewirtschaftung
+  und der Sanitärversorgung unterstützen und verstärken
+7.1-title: Bis 2030 den allgemeinen Zugang zu bezahlbaren, verlässlichen und modernen
+  Energiedienstleistungen sichern
+7.2-title: Bis 2030 den Anteil erneuerbarer Energie am globalen Energiemix deutlich
+  erhöhen
+7.3-title: Bis 2030 die weltweite Steigerungsrate der Energieeffizienz verdoppeln
+7.a-title: Bis 2030 die internationale Zusammenarbeit verstärken, um den Zugang zur
+  Forschung und Technologie im Bereich saubere Energie, namentlich erneuerbare Energie,
+  Energieeffizienz sowie fortschrittliche und saubere Technologien für fossile Brennstoffe,
+  zu erleichtern, und Investitionen in die Energieinfrastruktur und saubere Energietechnologien
+  fördern
+7.b-title: Bis 2030 die Infrastruktur ausbauen und die Technologie modernisieren,
+  um in den Entwicklungsländern und insbesondere in den am wenigsten entwickelten
+  Ländern, den kleinen Inselentwicklungsländern und den Binnenentwicklungsländern
+  im Einklang mit ihren jeweiligen Unterstützungsprogrammen moderne und nachhaltige
+  Energiedienstleistungen für alle bereitzustellen
+8.1-title: Ein Pro-Kopf-Wirtschaftswachstum entsprechend den nationalen Gegebenheiten
+  und insbesondere ein jährliches Wachstum des Bruttoinlandsprodukts von mindestens
+  7 Prozent in den am wenigsten entwickelten Ländern aufrechterhalten
+8.10-title: Die Kapazitäten der nationalen Finanzinstitutionen stärken, um den Zugang
+  zu Bank-, Versicherungs- und Finanzdienstleistungen für alle zu begünstigen und
+  zu erweitern
+8.2-title: Eine höhere wirtschaftliche Produktivität durch Diversifizierung, technologische
+  Modernisierung und Innovation erreichen, einschließlich durch Konzentration auf
+  mit hoher Wertschöpfung verbundene und arbeitsintensive Sektoren
+8.3-title: Entwicklungsorientierte Politiken fördern, die produktive Tätigkeiten,
+  die Schaffung menschenwürdiger Arbeitsplätze, Unternehmertum, Kreativität und Innovation
+  unterstützen, und die Formalisierung und das Wachstum von Kleinst-, Klein- und Mittelunternehmen
+  unter anderem durch den Zugang zu Finanzdienstleistungen begünstigen
+8.4-title: Bis 2030 die weltweite Ressourceneffizienz in Konsum und Produktion Schritt
+  für Schritt verbessern und die Entkopplung von Wirtschaftswachstum und Umweltzerstörung
+  anstreben, im Einklang mit dem Zehnjahres-Programmrahmen für nachhaltige Konsum-
+  und Produktionsmuster, wobei die entwickelten Länder die Führung übernehmen
+8.5-title: Bis 2030 produktive Vollbeschäftigung und menschenwürdige Arbeit für alle
+  Frauen und Männer, einschließlich junger Menschen und Menschen mit Behinderungen,
+  sowie gleiches Entgelt für gleichwertige Arbeit erreichen
+8.6-title: Bis 2020 den Anteil junger Menschen, die ohne Beschäftigung sind und keine
+  Schul- oder Berufsausbildung durchlaufen, erheblich verringern
+8.7-title: Sofortige und wirksame Maßnahmen ergreifen, um Zwangsarbeit abzuschaffen,
+  moderne Sklaverei und Menschenhandel zu beenden und das Verbot und die Beseitigung
+  der schlimmsten Formen der Kinderarbeit, einschließlich der Einziehung und des Einsatzes
+  von Kindersoldaten, sicherstellen und bis 2025 jeder Form von Kinderarbeit ein Ende
+  setzen
+8.8-title: Die Arbeitsrechte schützen und sichere Arbeitsumgebungen für alle Arbeitnehmer,
+  einschließlich der Wanderarbeitnehmer, insbesondere der Wanderarbeitnehmerinnen,
+  und der Menschen in prekären Beschäftigungsverhältnissen, fördern
+8.9-title: Bis 2030 Politiken zur Förderung eines nachhaltigen Tourismus erarbeiten
+  und umsetzen, der Arbeitsplätze schafft und die lokale Kultur und lokale Produkte
+  fördert
+8.a-title: Die im Rahmen der Handelshilfe gewährte Unterstützung für die Entwicklungsländer
+  und insbesondere die am wenigsten entwickelten Länder erhöhen, unter anderem durch
+  den Erweiterten integrierten Rahmenplan für handelsbezogene technische Hilfe für
+  die am wenigsten entwickelten Länder
+8.b-title: Bis 2020 eine globale Strategie für Jugendbeschäftigung erarbeiten und
+  auf den Weg bringen und den Globalen Beschäftigungspakt der Internationalen Arbeitsorganisation
+  umsetzen
+9.1-title: Eine hochwertige, verlässliche, nachhaltige und widerstandsfähige Infrastruktur
+  aufbauen, einschließlich regionaler und grenzüberschreitender Infrastruktur, um
+  die wirtschaftliche Entwicklung und das menschliche Wohlergehen zu unterstützen,
+  und dabei den Schwerpunkt auf einen erschwinglichen und gleichberechtigten Zugang
+  für alle legen
+9.2-title: Eine breitenwirksame und nachhaltige Industrialisierung fördern und bis
+  2030 den Anteil der Industrie an der Beschäftigung und am Bruttoinlandsprodukt entsprechend
+  den nationalen Gegebenheiten erheblich steigern und den Anteil in den am wenigsten
+  entwickelten Ländern verdoppeln
+9.3-title: Insbesondere in den Entwicklungsländern den Zugang kleiner Industrie- und
+  anderer Unternehmen zu Finanzdienstleistungen, einschließlich bezahlbaren Krediten,
+  und ihre Einbindung in Wertschöpfungsketten und Märkte erhöhen
+9.4-title: Bis 2030 die Infrastruktur modernisieren und die Industrien nachrüsten,
+  um sie nachhaltig zu machen, mit effizienterem Ressourceneinsatz und unter vermehrter
+  Nutzung sauberer und umweltverträglicher Technologien und Industrieprozesse, wobei
+  alle Länder Maßnahmen entsprechend ihren jeweiligen Kapazitäten ergreifen
+9.5-title: Die wissenschaftliche Forschung verbessern und die technologischen Kapazitäten
+  der Industriesektoren in allen Ländern und insbesondere in den Entwicklungsländern
+  ausbauen und zu diesem Zweck bis 2030 unter anderem Innovationen fördern und die
+  Anzahl der im Bereich Forschung und Entwicklung tätigen Personen je 1 Million Menschen
+  sowie die öffentlichen und privaten Ausgaben für Forschung und Entwicklung beträchtlich
+  erhöhen
+9.a-title: Die Entwicklung einer nachhaltigen und widerstandsfähigen Infrastruktur
+  in den Entwicklungsländern durch eine verstärkte finanzielle, technologische und
+  technische Unterstützung der afrikanischen Länder, der am wenigsten entwickelten
+  Länder, der Binnenentwicklungsländer und der kleinen Inselentwicklungsländer erleichtern
+9.b-title: Die einheimische Technologieentwicklung, Forschung und Innovation in den
+  Entwicklungsländern unterstützen, einschließlich durch Sicherstellung eines förderlichen
+  politischen Umfelds, unter anderem für industrielle Diversifizierung und Wertschöpfung
+  im Rohstoffbereich
+9.c-title: Den Zugang zur Informations- und Kommunikationstechnologie erheblich erweitern
+  sowie anstreben, in den am wenigsten entwickelten Ländern bis 2020 einen allgemeinen
+  und erschwinglichen Zugang zum Internet bereitzustellen

--- a/translations/en/global_goals.yml
+++ b/translations/en/global_goals.yml
@@ -1,63 +1,46 @@
-'1':
-  short: No poverty
-  title: End poverty in all its forms everywhere
-'10':
-  short: Reduced inequalities
-  title: Reduce inequality within and among countries
-'11':
-  short: Sustainable cities & communities
-  title: Make cities and human settlements inclusive, safe, resilient and sustainable
-'12':
-  short: Responsible consumption and production
-  title: Ensure sustainable consumption and production patterns
-'13':
-  short: Climate action
-  title: Take urgent action to combat climate change and its impacts
-'14':
-  short: Life below water
-  title: Conserve and sustainably use the oceans, seas and marine resources for sustainable
-    development
-'15':
-  short: Life on land
-  title: Protect, restore and promote sustainable use of terrestrial ecosystems, sustainably
-    manage forests, combat desertification, and halt and reverse land degradation
-    and halt biodiversity loss
-'16':
-  short: Peace and justice - strong institutions
-  title: Promote peaceful and inclusive societies for sustainable development, provide
-    access to justice for all and build effective, accountable and inclusive institutions
-    at all levels
-'17':
-  short: Partnerships for the goals
-  title: Strengthen the means of implementation and revitalize the Global Partnership
-    for Sustainable Development
-'2':
-  short: Zero hunger
-  title: End hunger, achieve food security and improved nutrition and promote sustainable
-    agriculture
-'3':
-  short: Good health and well-being
-  title: Ensure healthy lives and promote well-being for all at all ages
-'4':
-  short: Quality education
-  title: Ensure inclusive and equitable quality education and promote lifelong learning
-    opportunities for all
-'5':
-  short: Gender equality
-  title: Achieve gender equality and empower all women and girls
-'6':
-  short: Clean water and sanitation
-  title: Ensure availability and sustainable management of water and sanitation for
-    all
-'7':
-  short: Affordable and clean energy
-  title: Ensure access to affordable, reliable, sustainable and modern energy for
-    all
-'8':
-  short: Decent jobs and economic growth
-  title: Promote sustained, inclusive and sustainable economic growth, full and productive
-    employment and decent work for all
-'9':
-  short: Industry, innovation and infrastructure
-  title: Build resilient infrastructure, promote inclusive and sustainable industrialization
-    and foster innovation
+1-short: No poverty
+1-title: End poverty in all its forms everywhere
+10-short: Reduced inequalities
+10-title: Reduce inequality within and among countries
+11-short: Sustainable cities & communities
+11-title: Make cities and human settlements inclusive, safe, resilient and sustainable
+12-short: Responsible consumption and production
+12-title: Ensure sustainable consumption and production patterns
+13-short: Climate action
+13-title: Take urgent action to combat climate change and its impacts
+14-short: Life below water
+14-title: Conserve and sustainably use the oceans, seas and marine resources for sustainable
+  development
+15-short: Life on land
+15-title: Protect, restore and promote sustainable use of terrestrial ecosystems,
+  sustainably manage forests, combat desertification, and halt and reverse land degradation
+  and halt biodiversity loss
+16-short: Peace and justice - strong institutions
+16-title: Promote peaceful and inclusive societies for sustainable development, provide
+  access to justice for all and build effective, accountable and inclusive institutions
+  at all levels
+17-short: Partnerships for the goals
+17-title: Strengthen the means of implementation and revitalize the Global Partnership
+  for Sustainable Development
+2-short: Zero hunger
+2-title: End hunger, achieve food security and improved nutrition and promote sustainable
+  agriculture
+3-short: Good health and well-being
+3-title: Ensure healthy lives and promote well-being for all at all ages
+4-short: Quality education
+4-title: Ensure inclusive and equitable quality education and promote lifelong learning
+  opportunities for all
+5-short: Gender equality
+5-title: Achieve gender equality and empower all women and girls
+6-short: Clean water and sanitation
+6-title: Ensure availability and sustainable management of water and sanitation for
+  all
+7-short: Affordable and clean energy
+7-title: Ensure access to affordable, reliable, sustainable and modern energy for
+  all
+8-short: Decent jobs and economic growth
+8-title: Promote sustained, inclusive and sustainable economic growth, full and productive
+  employment and decent work for all
+9-short: Industry, innovation and infrastructure
+9-title: Build resilient infrastructure, promote inclusive and sustainable industrialization
+  and foster innovation

--- a/translations/en/global_indicators.yml
+++ b/translations/en/global_indicators.yml
@@ -1,2110 +1,476 @@
-1.1.1:
-  title: Proportion of population below the international poverty line, by sex, age,
-    employment status and geographical location (urban/rural)
-1.1.1a:
-  custodian_agency: World Bank (WB)
-  definition: The indicator Proportion of population below the international poverty
-    line is defined as the percentage of the population living on less than $1.90
-    a day at 2011 international prices. The 'international poverty line' is currently
-    set at $1.90 a day at 2011 international prices.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-01-01a.pdf
-1.1.1b:
-  custodian_agency: ILO
-  definition: Proportion of employed population below the international poverty line
-    of $1.90 per day, also referred to as the working poor, is defined as the proportion
-    of the employed population living in households with per-capita consumption or
-    income that is below the international poverty line of US$1.90.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-01-01b.pdf
-1.2.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-01.pdf
-  title: Proportion of population living below the national poverty line, by sex and
-    age
-1.2.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-02.pdf
-  title: Proportion of men, women and children of all ages living in poverty in all
-    its dimensions according to national definitions
-1.3.1:
-  title: Proportion of population covered by social protection floors/systems, by
-    sex, distinguishing children, unemployed persons, older persons, persons with
-    disabilities, pregnant women, newborns, work-injury victims and the poor and the
-    vulnerable
-1.3.1a:
-  custodian_agency: International Labour Organization (ILO)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-03-01a.pdf
-1.3.1b:
-  custodian_agency: World Bank (WB)
-  definition: Coverage of social protection and labor programs (SPL) is the percentage
-    of population participating in social insurance, social safety net, and unemployment
-    benefits and active labor market programs. Estimates include both direct and indirect
-    beneficiaries.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-03-01b.pdf
-1.4.1:
-  title: Proportion of population living in households with access to basic services
-1.4.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-04-02.pdf
-  title: Proportion of total adult population with secure tenure rights to land, (a)
-    with legally recognized documentation, and (b) who perceive their rights to land
-    as secure, by sex and type of tenure
-1.5.1:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: 'Death: The number of people who died during the disaster, or directly
-    after, as a direct result of the hazardous event  Missing: The number of people
-    whose whereabouts is unknown since the hazardous event. It includes people who
-    are presumed dead although there is no physical evidence. The data on number of
-    deaths and number of missing are mutually exclusive.  Affected: People who are
-    affected, either directly or indirectly, by a hazardous event.  Directly affected:
-    People who have suffered injury, illness or other health effects; who were evacuated,
-    displaced, relocated or have suffered direct damage to their livelihoods, economic,
-    physical, social, cultural and environmental assets.   Indirectly affected: People
-    who have suffered consequences, other than or in addition to direct effects, over
-    time due to disruption or changes in economy, critical infrastructures, basic
-    services, commerce, work or social, health and psychological consequences.  *
-    In this indicator, given the difficulties in assessing the full range of all affected
-    (directly and indirectly), number of affected. This indicator, while not perfect,
-    comes from data widely available and could be used consistently across countries
-    and over time to measure the achievement of the Target B of the Sendai Framework.  [a]
-    An open-ended intergovernmental expert working group on indicators and terminology
-    relating to disaster risk reduction established by the General Assembly (resolution
-    69/284) is developing a set of indicators to measure global progress in the implementation
-    of the Sendai Framework. These indicators will eventually reflect the agreements
-    on the Sendai Framework indicators.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-01.pdf
-  title: Number of deaths, missing persons and directly affected persons attributed
-    to disasters per 100,000 population
-1.5.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-02.pdf
-  title: Direct economic loss attributed to disasters in relation to global gross
-    domestic product (GDP)
-1.5.3:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: NA  [a] An open-ended intergovernmental expert working group on indicators
-    and terminology relating to disaster risk reduction established by the General
-    Assembly (resolution 69/284) is developing a set of indicators to measure global
-    progress in the implementation of the Sendai Framework. These indicators will
-    eventually reflect the agreements on the Sendai Framework indicators.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
-  title: Number of countries that adopt and implement national disaster risk reduction
-    strategies in line with the Sendai Framework for Disaster Risk Reduction 2015–2030
-1.5.4:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: NA  [a] An open-ended intergovernmental expert working group on indicators
-    and terminology relating to disaster risk reduction established by the General
-    Assembly (resolution 69/284) is developing a set of indicators to measure global
-    progress in the implementation of the Sendai Framework. These indicators will
-    eventually reflect the agreements on the Sendai Framework indicators.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-04.pdf
-  title: Proportion of local governments that adopt and implement local disaster risk
-    reduction strategies in line with national disaster risk reduction strategies
-1.a.1:
-  title: Proportion of domestically generated resources allocated by the government
-    directly to poverty reduction programmes
-1.a.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-0a-02.pdf
-  title: Proportion of total government spending on essential services (education,
-    health and social protection)
-1.a.3:
-  title: Sum of total grants and non-debt-creating inflows directly allocated to poverty
-    reduction programmes as a proportion of GDP
-1.b.1:
-  title: Proportion of government recurrent and capital spending to sectors that disproportionately
-    benefit women, the poor and vulnerable groups
-10.1.1:
-  custodian_agency: World Bank (WB)
-  definition: The growth rate in the welfare aggregate of bottom 40% is computed as
-    the annualized average growth rate in per capita real consumption or income of
-    the bottom 40% of the income distribution in a country from household surveys
-    over a roughly 5-year period. The national average growth rate in the welfare
-    aggregate is computed as the annualized average growth rate in per capita real
-    consumption or income of the total population in a country from household surveys
-    over a roughly 5-year period.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-01-01.pdf
-  title: Growth rates of household expenditure or income per capita among the bottom
-    40 per cent of the population and the total population
-10.2.1:
-  title: Proportion of people living below 50 per cent of median income, by sex, age
-    and persons with disabilities
-10.3.1:
-  title: Proportion of population reporting having personally felt discriminated against
-    or harassed in the previous 12 months on the basis of a ground of discrimination
-    prohibited under international human rights law
-10.4.1:
-  custodian_agency: International Labour Organization (ILO)
-  definition: Labour share of Gross Domestic Product (GDP) is the total compensation
-    of employees given as a percent of GDP, which is a measure of total output. It
-    provides information about the relative share of output which is paid as compensation
-    to employees as compared with the share paid to capital in the production process
-    for a given reference period.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-04-01.pdf
-  title: Labour share of GDP, comprising wages and social protection transfers
-10.5.1:
-  title: Financial Soundness Indicators
-10.6.1:
-  custodian_agency: Financing for Development Office, DESA (FFDO)
-  definition: The proportion of members and voting rights of developing countries
-    in international organizations has two components, the developing country proportion
-    of voting rights and the developing country proportion of membership in international
-    organisations. In some institutions these two components are identical.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-06-01.pdf
-  title: Proportion of members and voting rights of developing countries in international
-    organizations
-10.7.1:
-  title: Recruitment cost borne by employee as a proportion of yearly income earned
-    in country of destination
-10.7.2:
-  title: Number of countries that have implemented well-managed migration policies
-10.a.1:
-  custodian_agency: International Trade Centre (ITC),  United Nations Conference on
-    Trade and Development (UNCTAD),  The, World Trade Organization (WTO)
-  definition: Proportion of total number of tariff lines (in per cent) applied to
-    products imported from least developed countries and developing countries corresponding
-    to a 0% tariff rate in HS chapter 01-97.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-0A-01.pdf
-  title: Proportion of tariff lines applied to imports from least developed countries
-    and developing countries with zero-tariff
-10.b.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: Total resource flows for development, by recipient and donor countries
-    and type of flow comprises of Official Development Assistance (ODA), other official
-    flows (OOF) and private flows.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-0B-01.pdf
-  title: Total resource flows for development, by recipient and donor countries and
-    type of flow (e.g. official development assistance, foreign direct investment
-    and other flows)
-10.c.1:
-  custodian_agency: World Bank
-  definition: The target includes two components. The first component is that transaction
-    costs for migrant remittances should be 3% or less by 2030. This transaction cost
-    should be intended as Global average total cost of sending $200 (or equivalent
-    in local sending currency) and expressed as % of amount . This indicator is readily
-    available and published on a quarterly basis by the World Bank in the Remittance
-    Prices Worldwide database, which covers 365 country corridors, from 48 sending
-    to 105 receiving countries. The second component is to eliminate corridor where
-    cost is 5% or higher. This should be intended in the sense that it should be possible
-    for remittance senders to send money to the beneficiary for an average cost of
-    5% or less of the amount sent. For this purpose, it should suffice that in each
-    corridor there are at least 3 services, meeting a defined set of service requirements
-    (including service quality, reach etc.), for which the average is 5% or less.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-0c-01.pdf
-  title: Remittance costs as a proportion of the amount remitted
-11.1.1:
-  custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-01-01.pdf
-  title: Proportion of urban population living in slums, informal settlements or inadequate
-    housing
-11.2.1:
-  custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
-  definition: 'This indicator will be monitored by the proportion of the population
-    that has convenient access to public transport. The access to public transport
-    is considered convenient when an officially recognized stop is accessible within
-    a distance of 0.5 km from a reference point such as a home, school, work place,
-    market, etc. Additional criteria for defining public transport that is convenient
-    include: a. Public transport accessible to all special-needs customers, including
-    those who are physically, visually, and/or hearing-impaired, as well as those
-    with temporary disabilities, the elderly, children and other people in vulnerable
-    situations. b. Public transport with frequent service during peak travel times
-    c. Stops present a safe and comfortable station environment'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-02-01.pdf
-  title: Proportion of population that has convenient access to public transport,
-    by sex, age and persons with disabilities
-11.3.1:
-  custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
-  definition: The indicator is defined as the ratio of land consumption rate to population
-    growth rate.  This indicator requires defining the two components of population
-    growth and land consumption rate. Computing the population growth rate is more
-    straightforward and more readily available, while land consumption rate is slightly
-    challenging, and requires the use of new techniques. In estimating the land wetlands.
-    Secondly, there is not one unequivocal measure of whether land that is being developed
-    is -percentage of current total urban land that was newly developed (consumed)
-    will be used as a measure of the land consumption rate. The fully developed area
-    is also sometimes referred to as built up area.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-03-01.pdf
-  title: Ratio of land consumption rate to population growth rate
-11.3.2:
-  title: Proportion of cities with a direct participation structure of civil society
-    in urban planning and management that operate regularly and democratically
-11.4.1:
-  title: Total expenditure (public and private) per capita spent on the preservation,
-    protection and conservation of all cultural and natural heritage, by type of heritage
-    (cultural, natural, mixed and World Heritage Centre designation), level of government
-    (national, regional and local/municipal), type of expenditure (operating expenditure/investment)
-    and type of private funding (donations in kind, private non-profit sector and
-    sponsorship)
-11.5.1:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: 'Death: The number of people who died during the disaster, or directly
-    after, as a direct result of the hazardous event  Missing: The number of people
-    whose whereabouts is unknown since the hazardous event. It includes people who
-    are presumed dead although there is no physical evidence. The data on number of
-    deaths and number of missing are mutually exclusive.  Affected: People who are
-    affected, either directly or indirectly, by a hazardous event.  Directly affected:
-    People who have suffered injury, illness or other health effects; who were evacuated,
-    displaced, relocated or have suffered direct damage to their livelihoods, economic,
-    physical, social, cultural and environmental assets.   Indirectly affected: People
-    who have suffered consequences, other than or in addition to direct effects, over
-    time due to disruption or changes in economy, critical infrastructures, basic
-    services, commerce, work or social, health and psychological consequences.  *
-    In this indicator, given the difficulties in assessing the full range of all affected
-    (directly and indirectly), number of affected. This indicator, while not perfect,
-    comes from data widely available and could be used consistently across countries
-    and over time to measure the achievement of the Target B of the Sendai Framework.  [a]
-    An open-ended intergovernmental expert working group on indicators and terminology
-    relating to disaster risk reduction established by the General Assembly (resolution
-    69/284) is developing a set of indicators to measure global progress in the implementation
-    of the Sendai Framework. These indicators will eventually reflect the agreements
-    on the Sendai Framework indicators.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-01.pdf
-  title: Number of deaths, missing persons and directly affected persons attributed
-    to disasters per 100,000 population
-11.5.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-02.pdf
-  title: Direct economic loss in relation to global GDP, damage to critical infrastructure
-    and number of disruptions to basic services, attributed to disasters
-11.6.1:
-  custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
-  definition: Proportion of municipal solid waste regularly collected and with adequate
-    treatment and disposal out of total municipal solid waste generated.   The goal
-    of this indicator aims to generate the proportion of municipal solid waste regularly
-    collected and that is adequately treated and disposed out of all the total municipal
-    waste generated by the city.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-01.pdf
-  title: Proportion of urban solid waste regularly collected and with adequate final
-    discharge out of total urban solid waste generated, by cities
-11.6.2:
-  custodian_agency: World Health Organization (WHO)
-  definition: The mean annual concentration of fine suspended particles of less than
-    2.5 microns in diameters (PM2.5) is a common measure of air pollution. The mean
-    is a population-weighted average for urban population in a country, and is expressed
-    in micrograms per cubic meter [g/m3].
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-02.pdf
-  title: Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10) in cities
-    (population weighted)
-11.7.1:
-  custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
-  definition: Average share of the built-up area of cities that is open space for
-    public use for all  -surfaces including the urban vacant areas in and around them
-    but excluding rural areas beyond the urban f-taken.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-07-01.pdf
-  title: Average share of the built-up area of cities that is open space for public
-    use for all, by sex, age and persons with disabilities
-11.7.2:
-  title: Proportion of persons victim of physical or sexual harassment, by sex, age,
-    disability status and place of occurrence, in the previous 12 months
-11.a.1:
-  title: Proportion of population living in cities that implement urban and regional
-    development plans integrating population projections and resource needs, by size
-    of city
-11.b.1:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: NA  [a] An open-ended intergovernmental expert working group on indicators
-    and terminology relating to disaster risk reduction established by the General
-    Assembly (resolution 69/284) is developing a set of indicators to measure global
-    progress in the implementation of the Sendai Framework. These indicators will
-    eventually reflect the agreements on the Sendai Framework indicators.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-0B-01.pdf
-  title: Number of countries that adopt and implement national disaster risk reduction
-    strategies in line with the Sendai Framework for Disaster Risk Reduction 2015–2030
-11.b.2:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: NA  [a] An open-ended intergovernmental expert working group on indicators
-    and terminology relating to disaster risk reduction established by the General
-    Assembly (resolution 69/284) is developing a set of indicators to measure global
-    progress in the implementation of the Sendai Framework. These indicators will
-    eventually reflect the agreements on the Sendai Framework indicators.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-0B-02.pdf
-  title: Proportion of local governments that adopt and implement local disaster risk
-    reduction strategies in line with national disaster risk reduction strategies
-11.c.1:
-  title: Proportion of financial support to the least developed countries that is
-    allocated to the construction and retrofitting of sustainable, resilient and resource-efficient
-    buildings utilizing local materials
-12.1.1:
-  custodian_agency: United Nations Environment Programme, (UNEP)
-  definition: 'This indicator allows for the quantification (#) and monitoring of
-    countries making progress along the policy cycle of binding and non-binding policy
-    instruments aimed at supporting Sustainable Consumption and Production.   Sustainable
-    Consumption and Production: the working definition of Sustainable Consumption
-    and which respond to basic needs and bring a better quality of life while minimising
-    the use of natural resources and toxic materials as well as the emissions of waste
-    and pollutants over the life cycle of the 1   Policy: although quite flexible
-    and contexts specific, a policy is usually defined as a course of action that
-    has been officially agreed by an entity or an organization (governmental or non-governmental)
-    and is effectively implemented to achieve specific objectives.  Policy instruments
-    for sustainable consumption and production: policy instruments refer to the means  methodologies,
-    measures or interventions  that are used to achieve those objectives. In the case
-    of SCP, such instruments are designed and implemented to reduce the environmental
-    impacts of consumption and production patterns, with a view of generating economic
-    and/or social benefits.   Making progress along the policy cycle refers to the
-    development, adoption, implementation or evaluation of such policy instruments.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-12-01-01.pdf
-  title: Number of countries with sustainable consumption and production (SCP) national
-    action plans or SCP mainstreamed as a priority or a target into national policies
-12.2.1:
-  custodian_agency: United Nations Environment Programme (UNEP)
-  definition: Material Footprint (MF) is the attribution of global material extraction
-    to domestic final demand of a country. The total material footprint is the sum
-    of the material footprint for biomass, fossil fuels, metal ores and non-metal
-    ores.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-12-02-01.pdf
-  title: Material footprint, material footprint per capita, and material footprint
-    per GDP
-12.2.2:
-  custodian_agency: United Nations Environment Programme (UNEP)
-  definition: Domestic Material Consumption (DMC) is a standard material flow accounting
-    (MFA) indicator and reports the apparent consumption of materials in a national
-    economy.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-12-02-02.pdf
-  title: Domestic material consumption, domestic material consumption per capita,
-    and domestic material consumption per GDP
-12.3.1:
-  title: Global food loss index
-12.4.1:
-  custodian_agency: UN Environment, (United Nations Environment Programme)
-  definition: 'The indicator refers to the number of parties (=countries that have
-    ratified, accepted, approved or accessed), to the following Multilateral Environmental
-    Agreements (MEAs):  1. The Basel Convention on the Control of Transboundary Movements
-    of Hazardous Wastes and their Disposal (Basel Convention);  2. The Rotterdam Convention
-    on the prior informed consent procedure for certain hazardous chemicals and pesticides
-    in international trade (Rotterdam Convention); 3. The Stockholm Convention on
-    Persistent Organic Pollutants (Stockholm Convention); 4. The Montreal Protocol
-    on Substances that Deplete the Ozone Layer (Montreal Protocol); 5. Minamata Convention
-    on Mercury (Minamata Convention),  Which have submitted the information to the
-    Secretariat of each MEA, as required by each of the agreements.   The information
-    required is as follows:  Basel Convention1: 1. Designation of the Focal Point
-    and one or more Competent Authorities; 2. Submission of the annual national reports.  Rotterdam
-    Convention: 1. Designation of the Designated National Authority(-ies) and Official
-    contact points;                                                            1  The
-    parameters presented below are based on the obligations of the Parties to transmit
-    information to the Secretariat, whatever its national circumstances.  Other information
-    that only needs to be communicated to the Secretariat based on national circumstances,
-    such  as a possible national definitions of hazardous wastes, possible article
-    11 agreements under the Basel Convention, or a possible exemptions under the Stockholm
-    Convention would not be included, either because the Secretariat is not in a position
-    to assess whether the obligation to transmit information has materialized itself,
-    or because Parties have the right not to make use of a right. 2. Submission of
-    the import responses.   Stockholm Convention: 1. Designation of the Stockholm
-    Convention official contact points and national focal points; 2. Submission of
-    the national implementation plans;  3. Submission of the revised national implementation
-    plan addressing amendments;  4. Submission of the national reports.  Montreal
-    Protocol: 1. Compliance with reporting requirements for production and consumption
-    of ozone-depleting substances under (Article 7 of) the Montreal Protocol; 2. Submission
-    of information on Licensing systems under (Article 4B of) the Montreal Protocol.  Minamata
-    Convention: 1. Designation of a national focal point for exchange of information
-    under Article 17 of the Convention; 2. Submission of national reports as required
-    under Article 21 of the Minamata Convention.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-12-04-01.pdf
-  title: Number of parties to international multilateral environmental agreements
-    on hazardous waste, and other chemicals that meet their commitments and obligations
-    in transmitting information as required by each relevant agreement
-12.4.2:
-  title: Hazardous waste generated per capita and proportion of hazardous waste treated,
-    by type of treatment
-12.5.1:
-  title: National recycling rate, tons of material recycled
-12.6.1:
-  title: Number of companies publishing sustainability reports
-12.7.1:
-  title: Number of countries implementing sustainable public procurement policies
-    and action plans
-12.8.1:
-  title: Extent to which (i) global citizenship education and (ii) education for sustainable
-    development (including climate change education) are mainstreamed in (a) national
-    education policies; (b) curricula; (c) teacher education; and (d) student assessment
-12.a.1:
-  title: Amount of support to developing countries on research and development for
-    sustainable consumption and production and environmentally sound technologies
-12.b.1:
-  title: Number of sustainable tourism strategies or policies and implemented action
-    plans with agreed monitoring and evaluation tools
-12.c.1:
-  title: Amount of fossil-fuel subsidies per unit of GDP (production and consumption) and as a proportion of total national expenditure on fossil fuels
-13.1.1:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: 'Death: The number of people who died during the disaster, or directly
-    after, as a direct result of the hazardous event  Missing: The number of people
-    whose whereabouts is unknown since the hazardous event. It includes people who
-    are presumed dead although there is no physical evidence. The data on number of
-    deaths and number of missing are mutually exclusive.  Affected: People who are
-    affected, either directly or indirectly, by a hazardous event.  Directly affected:
-    People who have suffered injury, illness or other health effects; who were evacuated,
-    displaced, relocated or have suffered direct damage to their livelihoods, economic,
-    physical, social, cultural and environmental assets.   Indirectly affected: People
-    who have suffered consequences, other than or in addition to direct effects, over
-    time due to disruption or changes in economy, critical infrastructures, basic
-    services, commerce, work or social, health and psychological consequences.  *
-    In this indicator, given the difficulties in assessing the full range of all affected
-    (directly and indirectly), number of affected. This indicator, while not perfect,
-    comes from data widely available and could be used consistently across countries
-    and over time to measure the achievement of the Target B of the Sendai Framework.  [a]
-    An open-ended intergovernmental expert working group on indicators and terminology
-    relating to disaster risk reduction established by the General Assembly (resolution
-    69/284) is developing a set of indicators to measure global progress in the implementation
-    of the Sendai Framework. These indicators will eventually reflect the agreements
-    on the Sendai Framework indicators.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-01.pdf
-  title: Number of deaths, missing persons and directly affected persons attributed
-    to disasters per 100,000 population
-13.1.2:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: NA  [a] An open-ended intergovernmental expert working group on indicators
-    and terminology relating to disaster risk reduction established by the General
-    Assembly (resolution 69/284) is developing a set of indicators to measure global
-    progress in the implementation of the Sendai Framework. These indicators will
-    eventually reflect the agreements on the Sendai Framework indicators.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-02.pdf
-  title: Number of countries that adopt and implement national disaster risk reduction
-    strategies in line with the Sendai Framework for Disaster Risk Reduction 2015–2030
-13.1.3:
-  custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
-  definition: NA  [a] An open-ended intergovernmental expert working group on indicators
-    and terminology relating to disaster risk reduction established by the General
-    Assembly (resolution 69/284) is developing a set of indicators to measure global
-    progress in the implementation of the Sendai Framework. These indicators will
-    eventually reflect the agreements on the Sendai Framework indicators.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-03.pdf
-  title: Proportion of local governments that adopt and implement local disaster risk
-    reduction strategies in line with national disaster risk reduction strategies
-13.2.1:
-  title: Number of countries that have communicated the establishment or operationalization
-    of an integrated policy/strategy/plan which increases their ability to adapt to
-    the adverse impacts of climate change, and foster climate resilience and low greenhouse
-    gas emissions development in a manner that does not threaten food production (including
-    a national adaptation plan, nationally determined contribution, national communication,
-    biennial update report or other)
-13.3.1:
-  title: Number of countries that have integrated mitigation, adaptation, impact reduction
-    and early warning into primary, secondary and tertiary curricula
-13.3.2:
-  title: Number of countries that have communicated the strengthening of institutional,
-    systemic and individual capacity-building to implement adaptation, mitigation
-    and technology transfer, and development actions
-13.a.1:
-  title: Mobilized amount of United States dollars per year between 2020 and 2025 accountable towards the $100 billion commitment
-13.b.1:
-  title: Number of least developed countries and small island developing States that
-    are receiving specialized support, and amount of support, including finance, technology
-    and capacity-building, for mechanisms for raising capacities for effective climate
-    change-related planning and management, including focusing on women, youth and
-    local and marginalized communities
-14.1.1:
-  title: Index of coastal eutrophication and floating plastic debris density
-14.2.1:
-  title: Proportion of national exclusive economic zones managed using ecosystem-based
-    approaches
-14.3.1:
-  title: Average marine acidity (pH) measured at agreed suite of representative sampling
-    stations
-14.4.1:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  definition: The indicator Proportion of fish stocks within biologically sustainable
-    levels measures the sustainability of the world's marine capture fisheries by
-    their abundance. A fish stock of which abundance is at or greater than the level,
-    that can produce the maximum sustainable yield (MSY) is classified as biologically
-    sustainable. In contrast, when abundance falls below the MSY level, the stock
-    is considered biologically unsustainable.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-04-01.pdf
-  title: Proportion of fish stocks within biologically sustainable levels
-14.5.1:
-  custodian_agency: UN, Environment, World Conservation Monitoring Centre (UNEP-WCMC),
-    BirdLife International (BLI), International Union for Conservation of Nature (IUCN)
-  definition: The indicator Coverage of protected areas in relation to marine areas
-    shows temporal trends in the mean percentage of each important site for marine
-    biodiversity (i.e., those that contribute significantly to the global persistence
-    of biodiversity) that is covered by designated protected areas.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-05-01.pdf
-  title: Coverage of protected areas in relation to marine areas
-14.6.1:
-  custodian_agency: Food and Agriculture, Organisation of the United Nations
-  definition: Progress by countries in the degree of implementation of international
-    instruments aiming to combat illegal, unreported and unregulated fishing.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-06-01.pdf
-  title: Progress by countries in the degree of implementation of international instruments
-    aiming to combat illegal, unreported and unregulated fishing
-14.7.1:
-  title: Sustainable fisheries as a proportion of GDP in small island developing States,
-    least developed countries and all countries
-14.a.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-0a-01.pdf
-  title: Proportion of total research budget allocated to research in the field of
-    marine technology
-14.b.1:
-  custodian_agency: Food and Agriculture Organisation of the United Nations
-  definition: Progress by number of countries in the degree of application of a legal/regulatory/policy/institutional
-    framework which recognizes and protects access rights for small-scale fisheries.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-0b-01.pdf
-  title: Progress by countries in the degree of application of a legal/regulatory/policy/institutional
-    framework which recognizes and protects access rights for small-scale fisheries
-14.c.1:
-  title: Number of countries making progress in ratifying, accepting and implementing through legal, policy and institutional frameworks, ocean-related instruments that implement international law, as reflected in the United Nations Convention on the Law of the Sea, for the conservation and sustainable use of the oceans and their resources
-15.1.1:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  definition: Forest area as a proportion of total land area
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-01.pdf
-  title: Forest area as a proportion of total land area
-15.1.2:
-  custodian_agency: UN, Environment, World Conservation Monitoring Centre (UNEP-WCMC),
-    BirdLife, International (BLI), International Union for Conservation of Nature
-    (IUCN)
-  definition: This indicator Proportion of important sites for terrestrial and freshwater
-    biodiversity that are covered by protected areas shows temporal trends in the
-    mean percentage of each important site for terrestrial and freshwater biodiversity
-    (i.e., those that contribute significantly to the global persistence of biodiversity)
-    that is covered by designated protected areas.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-02.pdf
-  title: Proportion of important sites for terrestrial and freshwater biodiversity
-    that are covered by protected areas, by ecosystem type
-15.2.1:
-  custodian_agency: Food and Agriculture Organisation of the United Nations (FAO)
-  definition: 'target 15.2. It has been formally defined, by the UN General Assembly,
-    as follows:  [a] dynamic and evolving concept [that] aims to maintain and enhance
-    the economic, social and environmental values of all types of forests, for the
-    benefit of present and future generationsA/RES/62/98)  The indicator is composed
-    of five sub-indicators that measure progress towards all dimensions of sustainable
-    forest management. The environmental values of forests are covered by three sub-indicators
-    focused on the extension of forest area, biomass within the forest area and protection
-    and maintenance of biological diversity, and of natural and associated cultural
-    resources. Social and economic values of forests are reconciled with environmental
-    values through sustainable management plans. The sub-indicator provides further
-    qualification to management of forest areas, by assessing areas which are independently
-    verified for compliance with a set of national or international standards.  The
-    sub-indicators are:  Forest area net change rate   Above-ground biomass stock
-    in forest  Proportion of forest area located within legally established protect
-    areas  Proportion of forest area under a long term forest management plan  Forest
-    area under an independently verified forest management certification scheme  A
-    dashboard is used to assess progress related to the five sub-indicators. The adoption
-    of the dashboard approach provides for clear view of areas where progress towards
-    sustainable development goals has been achieved.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-02-01.pdf
-  title: Progress towards sustainable forest management
-15.3.1:
-  custodian_agency: United Nations Convention to Combat Desertification (UNCCD), and,
-    partners, including, the Food and Agriculture Organization of the United Nations
-    (FAO), United Nations Statistics Division (UNSD), United Nations Environment (UNEP),
-    United Nations Framework Convention on Climate Change (UNFCCC) and Convention
-    on Biological Diversity (CBD).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-03-01.pdf
-  title: Proportion of land that is degraded over total land area
-15.4.1:
-  definition: This indicator Coverage by protected areas of important sites for mountain
-    biodiversity shows temporal trends in the mean percentage of each important site
-    for mountain biodiversity (i.e., those that contribute significantly to the global
-    persistence of biodiversity) that is covered by designated protected areas.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-01.pdf
-  title: Coverage by protected areas of important sites for mountain biodiversity
-15.4.2:
-  custodian_agency: Food and Agriculture, Organization of the United Nations (FAO)
-  definition: The Green Cover Index is meant to measure the changes of the green vegetation
-    in mountain areas - i.e. forest, shrubs, trees, pasture land, crop land, etc.  in
-    order to monitor progress on the mountain target.   The index, will provide information
-    on the changes in the vegetation cover and, as such, will provide an indication
-    of the status of the conservation of mountain environments.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-02.pdf
-  title: Mountain Green Cover Index
-15.5.1:
-  custodian_agency: International Union for Conservation of Nature (IUCN), BirdLife
-    International (BLI)
-  definition: The Red List Index measures change in aggregate extinction risk across
-    groups of species. It is based on genuine changes in the number of species in
-    each category of extinction risk on The IUCN Red List of Threatened Species (IUCN
-    2015) is expressed as changes in an index ranging from 0 to 1.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-05-01.pdf
-  title: Red List Index
-15.6.1:
-  custodian_agency: Secretariat of the Convention on Biological Diversity, (CBD)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-06-01.pdf
-  title: Number of countries that have adopted legislative, administrative and policy
-    frameworks to ensure fair and equitable sharing of benefits
-15.7.1:
-  custodian_agency: United, Nations Office on Drugs and Crime (UNODC)
-  definition: The share of all trade in wildlife detected as being illegal
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-07-01.pdf
-  title: Proportion of traded wildlife that was poached or illicitly trafficked
-15.8.1:
-  custodian_agency: International Union for Conservation of Nature (IUCN)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-08-01.pdf
-  title: Proportion of countries adopting relevant national legislation and adequately
-    resourcing the prevention or control of invasive alien species
-15.9.1:
-  title: Progress towards national targets established in accordance with Aichi Biodiversity
-    Target 2 of the Strategic Plan for Biodiversity 2011–2020
-15.a.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: The indicator Official development assistance and public expenditure
-    on conservation and sustainable use of biodiversity and ecosystems is defined
-    as Gross disbursements of total ODA from all donors for biodiversity.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-0A-01.pdf
-  title: Official development assistance and public expenditure on conservation and
-    sustainable use of biodiversity and ecosystems
-15.b.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: The indicator Official development assistance and public expenditure
-    on conservation and sustainable use of biodiversity and ecosystems is defined
-    as Gross disbursements of total ODA from all donors for biodiversity.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-0B-01.pdf
-  title: Official development assistance and public expenditure on conservation and
-    sustainable use of biodiversity and ecosystems
-15.c.1:
-  custodian_agency: United, Nations Office on Drugs and Crime (UNODC)
-  definition: The share of all trade in wildlife detected as being illegal
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-0C-01.pdf
-  title: Proportion of traded wildlife that was poached or illicitly trafficked
-16.1.1:
-  custodian_agency: United Nations Office on Drugs and Crime (UNODC)
-  definition: 'The indicator is defined as the total count of victims of intentional
-    homicide divided by the total population, expressed per 100,000 population.  Intentional
-    homicide is defined as the unlawful death inflicted upon a person with the intent
-    to cause death or serious injury (Source: International Classification of Crime
-    for Statistical Purposes, ICCS 2015); population refers to total resident population
-    in a given country in a given year.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-01.pdf
-  title: Number of victims of intentional homicide per 100,000 population, by sex
-    and age
-16.1.2:
-  title: Conflict-related deaths per 100,000 population, by sex, age and cause
-16.1.3:
-  definition: The total number of persons who have been victim of physical, psychological
-    or sexual violence in the previous 12 months, as a share of the total population.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-03.pdf
-  title: Proportion of population subjected to (a) physical violence, (b) psychological
-    violence and (c) sexual violence in the previous 12 months
-16.1.4:
-  custodian_agency: United Nations Office on Drugs and Crime (UNODC)
-  definition: This indicator refers to the proportion of the population (adults) who
-    feel safe walking alone in their neighbourhood.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-04.pdf
-  title: Proportion of population that feel safe walking alone around the area they
-    live
-16.10.1:
-  definition: 'This indicator is defined as the number of verified cases of killing,
-    enforced disappearance, torture, arbitrary detention, kidnapping and other harmful
-    acts committed against journalists, trade unionists and human rights defenders
-    on an annual basis.  refers to everyone who observes, describes, documents and
-    analyses events, statements, policies, and any propositionsthat can affect society,
-    with the purpose of systematizing such information and gathering of facts and
-    analyses to inform sectors of society or soci ety as a whole, and others who share
-    these journalistic functions, including all media workers and support staff,   as   well  as   community   media  workers   and   so-      1
-    Current approved formulation of the indicator (E/2017/24-E/CN.3/2017/35). Informed
-    by ongoing efforts to improve the methodology of the indicator, and consultations
-    with relevant stakeholders, OHCHR, UNESCO and ILO have agreed to work towards
-    a refinement of the current formulation to streamline and closelyalign it with
-    target 16.10. The working draft of the proposed refinement is as follows:  of
-    verified cases of killing, enforced disappearance, torture, arbitrary detention,
-    kidnapping and other harmful acts against journalists, trade unionists and human
-    rights  The elements of the proposed refinement serves as the basisfor this metadata
-    and methodological approach. Goal 16: Promote peaceful and inclusive societies
-    for sustainable development, provide access to justice for all and build effective,
-    accountable and inclusive institutions at all levels Target 16.10: Ensure public
-    access to information and protect fundamental freedoms, in accordance with national
-    legislation and international agreements Indicator 16.10.1: Number of verified
-    cases of killing, kidnapping, enforced disappearance, arbitrary detention and
-    torture of journalists, associated media personnel, trade unionists and human
-    rights advocates in the previous 12 months1 2  momentarily play that role,2 professional
-    full-time reporters and analysts, as well as bloggers and others who engage in
-    forms of self-publication in print, on the internet or elsewhere.3  refers to
-    everyone exercising their right to form and to join trade unions for the protection
-    of their interests.4 A trade union is an association of workers organized to protect
-    and promote their common interests.5  refers to everyone exercising their right,
-    individually and in association with others, to promote and to strive for the
-    protection and realization of human rights and fundamental freedoms at national
-    and international levels,6 including some journalists and trade r is preferred
-    as it is more consistent with internationally agreed human rights standards and
-    established practice.  The different categories of violations tracked by the indicator
-    have been defined in accordance with international law and methodological standards
-    and monitoring practices developed by the OHCHR and other international mechanisms
-    and classified drawing on the International Classification of Crime for Statistical
-    Purposes (ICCS) disseminated by the UN Office of Drugs and Crime (UNODC). As such:    is
-    defined as any extrajudicial execution or other unlawful killing by State actors
-    or other actors acting with motivated by the victim, or someone associated with
-    the victim, engaging in activities as a journalist, trade unionist or human rights
-    defender; or while the victim was engaged in such activities; or by persons or
-    groups not acting with the support or acquiescence of the State whose harmful
-    acts were either motivated by the victim engaging in activities as a journalist,
-    trade unionist or human rights defender, and/or met by a failure of due diligence
-    on the part of the State in responding to these harmful acts, such a failu re
-    motivated by the victim or associate engaging in activities as a journalist, trade
-    unionist or human rights defender; and other unlawful attacks and destruction
-    in violation of corresponding to ICCS codes 0101, 0102 and 110139 and coded herein
-    as A [0101, 0102 and 110139].   refers to the arrest, detention, abduction or
-    any other form of deprivation of liberty of a victim by agents of the State or
-    by persons or groups of persons acting with the authorization, support or acquiescence
-    of the State, motivated by the victim, or someone associated with the victim,
-    engaging in activities as a journalist, trade unionist or human rights defender,
-    followed by a refusal to acknowledge the deprivation  2 A/HRC/20/17, para 4 3
-    Human Rights Committee, General Comment 34, para 44 4UDHR, Art. 23, 4, supplemented
-    by ICESCR, Article 8 5 ILO, Glossary on Labour Law and Industrial Relations (with
-    special reference to the European Union)(Geneva, 2005) p 250 6 Article 1, Declaration
-    on the Right and Responsibility of Individuals, Groups and Organs of Society to
-    Promote and Protect Universally Recognized Human Rights and Fundamental Freedoms,
-    UNGA Res 53/144, A/RES/53/144 3  of liberty or by concealment of the fate or whereabouts
-    of the victim, which places the victim outside the protection of the law, corresponding
-    to ICCS code 020222 (forced disappearance) and coded herein as B [02022ED]   refers
-    to any act by which severe pain or suffering, whether physical or mental, is intentionally
-    inflicted on a journalist, trade unionist or human rights defender, for such purposes
-    as obtaining from them or a third person information or a confession, punishing
-    them, intimidating them or coercing them, or for any reason based on discrimination
-    of any kind, when such pain or suffering is inflicted by or at the instigation
-    of or with the consent or acquiescence of a public official or other persons acting
-    in an official capacity, corresponding to ICCS code 11011 and coded herein as
-    C [11011].   refers to any arrest or detention not in accordance with national
-    laws, because it is not properly based on grounds established by law, or does
-    not conform to the procedures established by law, or is otherwise deemed arbitrary
-    in the sense of being inappropriate, unjust, unreasonable or unnecessary in the
-    circumstances, and motivated by the victim, or someone associated with the victim,
-    engaging in activities as a journalist, trade unionist or human rights defender,
-    corresponding to ICCS code 020222 (unlawful deprivation of liberty) and coded
-    herein as D [020222AD]   refers to unlawfully detaining, taking away and/or confining
-    a victim without their consent by persons or groups not acting with the support
-    or acquiescence of the State, and the unlawful detention and/or confinement was
-    met by a failure of due diligence on the part of the State in responding to the
-    unlawful detention, such a failure motivated by the victim or associate engaging
-    in activities as a journalist, trade unionist or human rights defender, corresponding
-    to ICCS codes 020221 and coded herein as E [020221]   refers to other acts by
-    State actors or other actors acting with the motivated by the victim engaging
-    in activities as a journalist, trade unionist or human rights defender, corresponding
-    to ICCS codes 0301, 0219, 110133, 02012, 0205, 0208, 0210 and 0211, and coded
-    herein as F [0301, 0219, 110133, 02012, 0205, 0208, 0210 and 0211].  refer to
-    reported cases that contain a minimum set of relevant information on particular
-    persons and circumstances, which have been reviewed by mandated bodies, mechanisms,
-    and institutions, and provided them with reasonable grounds to believe those persons
-    were victims of the above-mentioned human rights violations or abuses.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-01.pdf
-  title: Number of verified cases of killing, kidnapping, enforced disappearance,
-    arbitrary detention and torture of journalists, associated media personnel, trade
-    unionists and human rights advocates in the previous 12 months
-16.10.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-02.pdf
-  title: Number of countries that adopt and implement constitutional, statutory and/or
-    policy guarantees for public access to information
-16.2.1:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: Proportion of children aged 1-17 years who experienced any physical
-    punishment and/or psychological aggression by caregivers in the past month is
-    currently being measured by the Proportion of children aged 1-14 years who experienced
-    any physical punishment and/or psychological aggression by caregivers in the past
-    month.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-01.pdf
-  title: Proportion of children aged 1–17 years who experienced any physical punishment
-    and/or psychological aggression by caregivers in the past month
-16.2.2:
-  custodian_agency: United Nations Office on Drugs and Crime (UNODC)
-  definition: The indicator is defined as the ratio between the total number of victims
-    of trafficking in persons detected or living in a country and the population resident
-    in the country, expressed per 100,000 populations.  According to Article 3, paragraph
-    (a) of the UN Trafficking in Persons Protocol, trafficking in persons is threat
-    or use of force or other forms of coercion, of abduction, of fraud, of deception,
-    of the abuse of power or of a position of vulnerability or of the giving or receiving
-    of payments or benefits to achieve the consent of a person having control over
-    another person, for the purpose of exploitation. Exploitation shall include, at
-    a minimum, the exploitation of the prostitution of others or other forms of sexual
-    exploitation, forced labour or services, slavery or practices similar to slavery,
-    servitude or the removal of   he consent of a victim of trafficking in persons
-    to the intended exploitation set forth in subparagraph (a) of this article shall
-    be irrelevant where any of the means set forth in subparagraph (a)   ransportation,
-    transfer, harbouring or receipt of a child for the purpose of exploitation shall
-    be considered trafficking in persons even if this does not involve any of the
-    means set forth in subparagraph (a);"
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-02.pdf
-  title: Number of victims of human trafficking per 100,000 population, by sex, age
-    and form of exploitation
-16.2.3:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: Proportion of young women and men aged 18-29 years who experienced sexual
-    violence by age 18
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-03.pdf
-  title: Proportion of young women and men aged 18–29 years who experienced sexual
-    violence by age 1
-16.3.1:
-  custodian_agency: United Nations Office on Drugs and Crime (UNODC)
-  definition: Number of victims of violent crime in the previous 12 months who reported
-    their victimization to competent authorities or other officially recognized conflict
-    resolution mechanisms, as a percentage of all victims of violent crime in the
-    previous 12 months
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-03-01.pdf
-  title: Proportion of victims of violence in the previous 12 months who reported
-    their victimization to competent authorities or other officially recognized conflict
-    resolution mechanisms
-16.3.2:
-  definition: The total number of persons held in detention who have not yet been
-    sentenced, as a percentage of the total number of persons held in detention, on
-    a specified date.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-03-02.pdf
-  title: Unsentenced detainees as a proportion of overall prison population
-16.4.1:
-  title: Total value of inward and outward illicit financial flows (in current United
-    States dollars)
-16.4.2:
-  title: Proportion of seized, found or surrendered arms whose illicit origin or context
-    has been traced or established by a competent authority in line with international
-    instruments
-16.5.1:
-  custodian_agency: United Nations Office on Drugs and Crime (UNODC)
-  definition: This indicator is defined as the percentage of persons who paid at least
-    one bribe (gave a public official money, a gift or counter favour) to a public
-    official, or were asked for a bribe by these public officials, in the last 12
-    months, as a percentage of persons who had at least one contact with a public
-    official in the same period.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-05-01.pdf
-  title: Proportion of persons who had at least one contact with a public official
-    and who paid a bribe to a public official, or were asked for a bribe by those
-    public officials, during the previous 12 months
-16.5.2:
-  custodian_agency: World Bank (WB)
-  definition: Proportion of firms asked for a gift or informal payment when meeting
-    with tax officials.   In every Enterprise Survey (www.enterprisesurveys.org),
-    there is a standard question which asks the survey respondent if they were inspected
-    by or required to meet with tax officials. If the respondent -up question which
-    asks if the respondent was expected to provide a gift or an informal payment dur  Enterprise
-    Surveys are firm-level surveys conducted in World Bank client countries. The survey
-    focuses on various aspects of the business environment as productivity, etc. The
-    surveys are conducted via face-to-face interviews with the top manager or business
-    owner. For each country, the survey is conducted approximately every 4-5 years.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-05-02.pdf
-  title: Proportion of businesses that had at least one contact with a public official
-    and that paid a bribe to a public official, or were asked for a bribe by those
-    public officials during the previous 12 months
-16.6.1:
-  custodian_agency: World Bank (WB)
-  definition: Primary government expenditures as a proportion of original approved
-    budget  This indicator measures the extent to which aggregate budget expenditure
-    outturn reflects the amount originally approved, as defined in government budget
-    documentation and fiscal reports. The coverage is budgetary central government
-    (BCG) and the time period covered is the last three completed fiscal years.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-06-01.pdf
-  title: Primary government expenditures as a proportion of original approved budget,
-    by sector (or by budget codes or similar)
-16.6.2:
-  title: Proportion of population satisfied with their last experience of public services
-16.7.1:
-  title: Proportions of positions (by sex, age, persons with disabilities and population
-    groups) in public institutions (national and local legislatures, public service,
-    and judiciary) compared to national distributions
-16.7.2:
-  title: Proportion of population who believe decision-making is inclusive and responsive,
-    by sex, age, disability and population group
-16.8.1:
-  definition: 'The indicator Proportion of members and voting rights of developing
-    countries in international organizations has two components, the developing country
-    proportion of voting rights and the developing country proportion of membership
-    in international organisations. In some institutions these two components are
-    identical.  The indicator is calculated independently for eleven different international
-    institutions: The United Nations General Assembly, the United Nations Security
-    Council, the United Nations Economic and Social Council, the International Monetary
-    Fund, the International Bank for Reconstruction and Development, the International
-    Finance Corporation, the African Development Bank, the Asian Development Bank,
-    the Inter-American Development Bank, the World Trade Organisation, and the Financial
-    Stability Board.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-08-01.pdf
-  title: Proportion of members and voting rights of developing countries in international
-    organizations
-16.9.1:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: Proportion of children under 5 years of age whose births have been registered
-    with a civil authority.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-09-01.pdf
-  title: Proportion of children under 5 years of age whose births have been registered
-    with a civil authority, by age
-16.a.1:
-  custodian_agency: United Nations Office of the High Commissioner for Human Rights
-  definition: This indicator Existence of independent national human rights institutions
-    in compliance with the Paris Principles measures the compliance of existing national
-    human rights institutions with the Principles relating to the Status of National
-    Institutions (The Paris Principles), which were adopted by the General Assembly
-    (resolution 48/134) based on the rules of procedure of the Global Alliance of
-    National Human Rights Institutions (GANHRI, formerly the International Coordinating
-    Committee of National Institutions for the Promotion and Protection of Human Rights
-    or ICC).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-0A-01.pdf
-  title: Existence of independent national human rights institutions in compliance
-    with the 'Paris Principles'
-16.b.1:
-  title: Proportion of population reporting having personally felt discriminated against
-    or harassed in the previous 12 months on the basis of a ground of discrimination
-    prohibited under international human rights law
-17.1.1:
-  custodian_agency: IMF Statistics Department (Government Finance Division)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-01-01.pdf
-  title: Total government revenue as a proportion of GDP, by source
-17.1.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-01-02.pdf
-  title: Proportion of domestic budget funded by domestic taxes
-17.10.1:
-  custodian_agency: International Trade Centre (ITC),  United Nations Conference on
-    Trade and Development (UNCTAD),  The, World Trade Organization (WTO)
-  definition: Value in percentage of weighted average tariffs applied to the imports
-    of goods in HS chapter 01-97.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-10-01.pdf
-  title: Worldwide weighted tariff-average
-17.11.1:
-  custodian_agency: International Trade Centre (ITC),  United Nations Conference on
-    Trade and Development (UNCTAD),  The, World Trade Organization (WTO)
-  definition: Exports by developing countries and LDCs as a share of global exports
-    of goods and services
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-11-01.pdf
-  title: Developing countries’ and least developed countries’ share of global exports
-17.12.1:
-  custodian_agency: International Trade Centre (ITC),  United Nations Conference on
-    Trade and Development (UNCTAD),  The, World Trade Organization (WTO)
-  definition: Average import tariffs (in per cent) faced by products exported from
-    developing countries and least developed countries.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-12-01.pdf
-  title: Average tariffs faced by developing countries, least developed countries
-    and small island developing States
-17.13.1:
-  title: Macroeconomic Dashboard
-17.14.1:
-  title: Number of countries with mechanisms in place to enhance policy coherence
-    of sustainable development
-17.15.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD),  United
-    Nations Development Programme (UNDP)
-  definition: This indicator measures the extent to which, and the ways in which,
-    all concerned development partners use country-led results frameworks (CRFs) to
-    plan development cooperation efforts and assess their performance.    The indicator
-    assesses the degree to which providers of development cooperation (i.e. development
-    partners) design their interventions by relying on objectives and results indicators
-    that are drawn from country government-led results frameworks
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-15-01.pdf
-  title: Extent of use of country-owned results frameworks and planning tools by providers
-    of development cooperation
-17.16.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD),  United
-    Nations Development Programme (UNDP)
-  definition: The indicator tracks the number of countries reporting progress in multi
-    stakeholder monitoring frameworks that track the implementation of development
-    effectiveness commitments supporting the achievement of sustainable development
-    goals (SDGs).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-16-01.pdf
-  title: Number of countries reporting progress in multi-stakeholder development effectiveness
-    monitoring frameworks that support the achievement of the sustainable development
-    goals
-17.17.1:
-  title: Amount of United States dollars committed to (a) public-private partnerships
-    and (b) civil society partnerships
-17.18.1:
-  title: Proportion of sustainable development indicators produced at the national
-    level with full disaggregation when relevant to the target, in accordance with
-    the Fundamental Principles of Official Statistics
-17.18.2:
-  custodian_agency: Partnership in Statistics for Development in the 21st Century,
-    (PARIS21)
-  definition: The indicator refers to the number of countries that have national statistical
-    legislation that complies with the Fundamental Principles of Official Statistics.
-    This refers to the number of countries that have a statistical legislation which
-    respects the principles of UNFOP.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-02.pdf
-  title: Number of countries that have national statistical legislation that complies
-    with the Fundamental Principles of Official Statistics
-17.18.3:
-  custodian_agency: Partnership in Statistics for Development in the 21st Century,
-    (PARIS21)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-03.pdf
-  title: Number of countries with a national statistical plan that is fully funded
-    and under implementation, by source of funding
-17.19.1:
-  custodian_agency: Partnership in Statistics for Development in the 21st Century
-    (PARIS21)
-  definition: The indicator Dollar value of all resources made available to strengthen
-    statistical capacity in developing countries is based on the Partner Report on
-    Support to Statistics (PRESS) that is designed and administered by PARIS21 to
-    provide a snapshot of the US dollar value of ongoing statistical support in developing
-    countries.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-01.pdf
-  title: Dollar value of all resources made available to strengthen statistical capacity
-    in developing countries
-17.19.2:
-  custodian_agency: United Nations Statistics Division (UNSD)
-  definition: This information only refers to 17.19.2 (a)   The indicator tracks the
-    proportion of countries that have conducted at least one population and housing
-    census in the last 10 years. This also includes countries which compile their
-    detailed population and housing statistics from population registers, administrative
-    records, sample surveys or other sources or a combination of those sources.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-02.pdf
-  title: Proportion of countries that (a) have conducted at least one population and
-    housing census in the last 10 years; and (b) have achieved 100 per cent birth
-    registration and 80 per cent death registration
-17.19.2a:
-  custodian_agency: United Nations Statistics Division (UNSD)
-  definition: This information only refers to 17.19.2 (a)   The indicator tracks the
-    proportion of countries that have conducted at least one population and housing
-    census in the last 10 years. This also includes countries which compile their
-    detailed population and housing statistics from population registers, administrative
-    records, sample surveys or other sources or a combination of those sources.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-02a.pdf
-17.19.2b:
-  custodian_agency: United Nations Statistics Division (UNSD), Department of Economic
-    and Social Affairs, United Nations
-  definition: 'This information only refers to 17.19.2 (b): Proportion of countries
-    that have achieved 100 per cent birth registration and 80 per cent death registration  According
-    to the Principles and Recommendations for a Vital Statistics System, Revision
-    3 (https://unstats.un.org/unsd/demographic/standmeth/principles/M19Rev3en.pdf),
-    a complete civil registration The registration in the civil registration system
-    of every vital event that has occurred to the members of the population of a particular
-    country (or area), within a specified period as a result of which every such event
-    has a vital registration record and the system has attained 100 per cent coverage.  In
-    a given country or area, the level of completeness of birth registration can be
-    different from the level of completeness of death registration.   There exist
-    several methods for the evaluation of completeness of birth or death registration
-    systems.  An elaboration of these methods is available at Principles and Recommendations
-    for a Vital Statistics System, Revision 3.  The evaluation and monitoring of quality
-    and completeness  of birth and death registration systems are addressed in Part
-    three, sub-Chapters: D. Quality assessment methods; E. Direct versus indirect
-    assessment,  and F. Choosing appropriate methods for assessing completeness and
-    qualitative accuracy of registration and register-based vital statistics (para
-    579 to 622).  Indicator 17.19.2(b) has two parts; the first concerning the birth
-    registration and the second concerning the death registration of each individual
-    country or area.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-02b.pdf
-17.2.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: The indicator Net official development assistance, total and to least
-    developed countries, as a proportion of the Organization for Economic Cooperation
-    and Development (OECD) Development Assistance Committee donors' gross national
-    income (GNI) is defined as Net ODA disbursements as a per cent of GNI.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-02-01.pdf
-  title: Net official development assistance, total and to least developed countries,
-    as a proportion of the Organization for Economic Cooperation and Development (OECD)
-    Development Assistance Committee donors’ gross national income (GNI)
-17.3.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: 'ODA PART: ODA disbursements'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-03-01.pdf
-  title: Foreign direct investment (FDI), official development assistance and South-South cooperation as a proportion of total domestic budget
-17.3.2:
-  custodian_agency: World Bank (WB)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-03-02.pdf
-  title: Volume of remittances (in United States dollars) as a proportion of total
-    GDP
-17.4.1:
-  custodian_agency: World Bank (WB)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-04-01.pdf
-  title: Debt service as a proportion of exports of goods and services
-17.5.1:
-  title: Number of countries that adopt and implement investment promotion regimes
-    for least developed countries
-17.6.1:
-  title: Number of science and/or technology cooperation agreements and programmes
-    between countries, by type of cooperation
-17.6.2:
-  custodian_agency: International Telecommunication Union (ITU)
-  definition: 'The indicator fixed Internet broadband subscriptions, by speed, refers
-    to the number of fixed-broadband subscriptions to the public Internet, split by
-    advertised download speed.  The indicator is currently broken down by the following
-    subscription speeds:  - 256 kbit/s to less than 2 Mbit/s subscriptions: Refers
-    to all fixed broadband Internet subscriptions with advertised downstream speeds
-    equal to, or greater than, 256 kbit/s and less than 2 Mbit/s.  - 2 Mbit/s to less
-    than 10 Mbit/s subscriptions: Refers to all fixed -broadband Internet subscriptions
-    with advertised downstream speeds equal to, or greater than, 2 Mbit/s and less
-    than 10 Mbit/s.  - Equal to or above 10 Mbit/s subscriptions (4213_G10). Refers
-    to all fixed -broadband Internet subscriptions with advertised downstream speeds
-    equal to, or greater than, 10 Mbit/s.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-06-02.pdf
-  title: Fixed Internet broadband subscriptions per 100 inhabitants, by speed
-17.7.1:
-  title: Total amount of approved funding for developing countries to promote the
-    development, transfer, dissemination and diffusion of environmentally sound technologies
-17.8.1:
-  custodian_agency: International Telecommunication Union (ITU)
-  definition: The indicator proportion of individuals using the Internet is defined
-    as the proportion of individuals who used the Internet from any location in the
-    last three months.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-08-01.pdf
-  title: Proportion of individuals using the Internet
-17.9.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: Gross disbursements of total ODA and other official flows from all donors
-    for capacity building and national planning.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-09-01.pdf
-  title: Dollar value of financial and technical assistance (including through North-South,
-    South‐South and triangular cooperation) committed to developing countries
-2.1.1:
-  custodian_agency: Food and Agriculture Organization of the United Nations (UN FAO)
-  definition: 'The prevalence of undernourishment (PoU) (French: pourcentage de sous-alimentation;
-    Spanish: porcentaje de sub-alimentación; Italian: prevalenza di sotto-alimentazione)
-    is an estimate of the proportion of the population whose habitual food consumption
-    is insufficient to provide the dietary energy levels that are required to maintain
-    a normal active and healthy life. It is expressed as a percentage.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-01-01.pdf
-  title: Prevalence of undernourishment
-2.1.2:
-  definition: The indicator measures the percentage of individuals in the population
-    who have experienced food insecurity at moderate or severe levels during the reference
-    period. The severity of food insecurity, defined as a latent trait, is measured
-    on the Food Insecurity Experience Scale global reference scale, a measurement
-    standard established by FAO through the application of the Food Insecurity Experience
-    Scale in more than 140 countries worldwide, starting in 2014.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-01-02.pdf
-  title: Prevalence of moderate or severe food insecurity in the population, based
-    on the Food Insecurity Experience Scale (FIES)
-2.2.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-01.pdf
-  title: Prevalence of stunting (height for age <-2 standard deviation from the median
-    of the World Health Organization (WHO) Child Growth Standards) among children
-    under 5 years of age
-2.2.2:
-  title: Prevalence of malnutrition (weight for height >+2 or <-2 standard deviation
-    from the median of the WHO Child Growth Standards) among children under 5 years
-    of age, by type (wasting and overweight)
-2.2.2a:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-02a.pdf
-2.2.2b:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-02b.pdf
-2.3.1:
-  title: Volume of production per labour unit by classes of farming/pastoral/forestry
-    enterprise size
-2.3.2:
-  title: Average income of small-scale food producers, by sex and indigenous status
-2.4.1:
-  title: Proportion of agricultural area under productive and sustainable agriculture
-2.5.1:
-  custodian_agency: Food and Agriculture Organization of the United Nations (UN FAO)
-  definition: The conservation of plant and animal genetic resources for food and
-    agriculture (GRFA) in medium or long term conservation facilities (ex situ in
-    genebanks) represents the most trusted means of conserving genetic resources worldwide.
-    Plant and animal GRFA conserved in these facilities can be easily used in breeding
-    programmes as well, even directly on-farm.  The measure of trends in ex situ conserved
-    materials provides an overall assessment of the extent to which we are managing
-    to maintain and/or increase the total genetic diversity available for future use
-    and thus protected from any permanent loss of genetic diversity which may occur
-    in the natural habitat, i.e. in situ, or on-farm.  The two components of the indicator,
-    plant and animal GRFA, are separately counted.  Plant genetic resources  The plant
-    component is calculated as the number of accessions of plant genetic resources
-    secured in sample of seeds, planting materials or plants which is maintained in
-    a genebank. Genebank Standards for Plant Genetic Resources for Food and Agriculture
-    (accessible at http://www.fao.org/documents/card/en/c/7b79ee93-0f3c-5f58-9adc-5d4ef063f9c7/),
-    set the benchmark for current scientific and technical best practices for conserving
-    plant genetic resources, and support key international policy instruments for
-    the conservation and use of plant genetic resources. These voluntary standards
-    have been endorsed by the FAO Commission on Genetic Resources for Food and Agriculture
-    at its Fourteenth Regular Session (http://www.fao.org/docrep/meeting/028/mg538e.pdf).   Animal
-    genetic resources  The animal component is calculated as the number of local breeds
-    stored within a genebank collection with an amount of genetic material stored
-    which is required to reconstitute the breed (based on the Guidelines on Cryconservation
-    of Animal Genetic Resources, FAO, 2012, accessible at http://www.fao.org/docrep/016/i3017e/i3017e00.htm).
-    The guidelines have been endorsed by the Commission on Genetic Resources for Food
-    and Agriculture at its Thirteenth Regular Session (http://www.fao.org/docrep/meeting/024/mc192e.pdf).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-01.pdf
-  title: Number of plant and animal genetic resources for food and agriculture secured
-    in either medium- or long-term conservation facilities
-2.5.2:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  definition: The indicator presents the percentage of livestock breeds classified
-    as being at risk, not at risk or of unknown risk of extinctions at a certain moment
-    in time, as well as the trends for those percentages.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-02.pdf
-  title: Proportion of local breeds classified as being at risk, not at risk or at
-    unknown level of risk of extinction
-2.a.1:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  definition: The Agriculture Orientation Index (AOI) for Government Expenditures
-    is defined as the Agriculture Share of Government Expenditures, divided by the
-    Agriculture Share of GDP, where Agriculture refers to the agriculture, forestry,
-    fishing and hunting sector. The measure in a currency-free index, calculated as
-    the ratio of these two shares. National governments are requested to compile Government
-    Expenditures according to the international Classification of Functions of Government
-    (COFOC), and Agriculture Share of GDP according to the System of National Accounts
-    (SNA).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-01.pdf
-  title: The 'agriculture orientation index' for government expenditures
-2.a.2:
-  definition: Gross disbursements of total ODA and other official flows from all donors
-    to the agriculture sector.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-02.pdf
-  title: Total official flows (official development assistance plus other official
-    flows) to the agriculture sector
-2.b.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0B-01.pdf
-  title: Agricultural export subsidies
-2.b.2:
-  custodian_agency: The World Trade Organization (WTO)
-  definition: 'Agricultural export subsidies are defined as export subsidies budgetary
-    outlays and quantities as notified by WTO Members in Tables ES:1 and supporting
-    Tables ES:2 (following templates in document G/AG/2 dated 30 June 1995).  Data
-    cover: Schedules; e 9.4 of the Agreement on Agriculture.  Other WTO Members are
-    not entitled to use export subsidies and their notifications are therefore not
-    recorded in the indicator series.  Budgetary outlays and quantities are expressed
-    in a currency (national or other) and in quantity units as per Member''s notification
-    practices. For Members with export subsidy reduction commitments included in part
-    IV of their Schedules, the currency used in the notifications is similar to the
-    one used in the Schedules.  Data are available by country and by products or groups
-    of products, according to Members'' schedules for Members with export subsidy
-    reduction commitments included in part IV of their Schedules and according to
-    Member''s notification practices in the case of developing country Members using
-    export subsidies under the provisions of article 9.4 of the Agreement on Agriculture."'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0B-02.pdf
-  title: Agricultural export subsidies
-2.c.1:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  definition: The indicator of food price anomalies (IFPA) identifies abnormally high
-    or low prices that occur for a food commodity price series over a given period
-    of time
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0C-01.pdf
-  title: Indicator of food price anomalies
-3.1.1:
-  custodian_agency: World Health Organization (WHO)
-  definition: 'The maternal mortality ratio (MMR) is defined as the number of maternal
-    deaths during a given time period per 100,000 live births during the same time
-    period. It depicts the risk of maternal death relative to the number of live births
-    and essentially captures the risk of death in a single pregnancy or a single live
-    birth. Maternal deaths: The annual number of female deaths from any cause related
-    to or aggravated by pregnancy or its management (excluding accidental or incidental
-    causes) during pregnancy and childbirth or within 42 days of termination of pregnancy,
-    irrespective of the duration and site of the pregnancy, expressed per 100,000
-    live births, for a specified time period.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-01.pdf
-  title: Maternal mortality ratio
-3.1.2:
-  definition: Percentage of births attended by skilled health personnel (generally
-    doctors, nurses or midwives) is the percentage of deliveries attended by health
-    personnel trained in providing lifesaving obstetric care, including giving the
-    necessary supervision, care and advice to women during pregnancy, labour and the
-    post-partum period, conducting deliveries on their own, and caring for newborns.
-    Traditional birth attendants, even if they receive a short training course, are
-    not included.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-02.pdf
-  title: Proportion of births attended by skilled health personnel
-3.2.1:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: Under-five mortality is the probability of a child born in a specific
-    year or period dying before reaching the age of 5 years, if subject to age specific
-    mortality rates of that period, expressed per 1000 live births.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-02-01.pdf
-  title: Under-5 mortality rate
-3.2.2:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: The neonatal mortality rate is the probability that a child born in
-    a specific year or period will die during the first 28 completed days of life
-    if subject to age-specific mortality rates of that period, expressed per 1000
-    live births.  Neonatal deaths (deaths among live births during the first 28 completed
-    days of life) may be subdivided into early neonatal deaths, occurring during the
-    first 7 days of life, and late neonatal deaths, occurring after the 7th day but
-    before the 28th completed day of life.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-02-02.pdf
-  title: Neonatal mortality rate
-3.3.1:
-  custodian_agency: The Joint United Nations Programme on HIV/AIDS (UNAIDS)
-  definition: The number of new HIV infections per 1,000 uninfected population, by
-    sex, age and key populations as defined as the number of new HIV infections per
-    1000 person-years among the uninfected population.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-01.pdf
-  title: Number of new HIV infections per 1,000 uninfected population, by sex, age
-    and key populations
-3.3.2:
-  custodian_agency: World Health Organization (WHO)
-  definition: The tuberculosis incidence per 100,000 population as defined as the
-    estimated number of new and relapse TB cases (all forms of TB, including cases
-    in people living with HIV) arising in a given year, expressed as a rate per 100
-    000 population.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-02.pdf
-  title: Tuberculosis incidence per 100,000 population
-3.3.3:
-  definition: Incidence of malaria is defined as the number of new cases of malaria
-    per 1,000 people at risk each year.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-03.pdf
-  title: Malaria incidence per 1,000 population
-3.3.4:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-04.pdf
-  title: Hepatitis B incidence per 100,000 population
-3.3.5:
-  custodian_agency: World Health Organization (WHO)
-  definition: Number of people requiring treatment and care for any one of the neglected
-    tropical diseases (NTDs) targeted by the WHO NTD Roadmap and World Health Assembly
-    resolutions and reported to WHO.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-05.pdf
-  title: Number of people requiring interventions against neglected tropical diseases
-3.4.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-04-01.pdf
-  title: Mortality rate attributed to cardiovascular disease, cancer, diabetes or
-    chronic respiratory disease
-3.4.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-04-02.pdf
-  title: Suicide mortality rate
-3.5.1:
-  title: Coverage of treatment interventions (pharmacological, psychosocial and rehabilitation
-    and aftercare services) for substance use disorders
-3.5.2:
-  custodian_agency: World Health Organization (WHO)
-  definition: Harmful use of alcohol, defined according to the national context as
-    alcohol per capita consumption (aged 15 years and older) within a calendar year
-    in litres of pure alcohol  Total alcohol per capita consumption (APC) is defined
-    as the total (sum of recorded APC three-year average and unrecorded APC as a proportion
-    of total) amount of alcohol consumed per adult (15+ years) over a calendar year,
-    in litres of pure alcohol, adjusted for tourist consumption. Recorded alcohol
-    consumption refers to official statistics at country level (production, import,
-    export, and sales or taxation data), while the unrecorded alcohol consumption
-    refers to alcohol which is not taxed and is outside the usual system of governmental
-    control, such as home or informally produced alcohol (legal or illegal), smuggled
-    alcohol, surrogate alcohol (which is alcohol not intended for human consumption),
-    or alcohol obtained through cross-border shopping (which is recorded in a different
-    jurisdiction). Tourist consumption takes into account tourists visiting the country
-    and inhabitants visiting other countries. Positive figures denote alcohol consumption
-    of outbound tourists being greater than alcohol consumption by inbound tourists,
-    negative numbers the opposite. Tourist consumption is based on UN statistics,
-    and data are provided by IHME.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-05-02.pdf
-  title: Harmful use of alcohol, defined according to the national context as alcohol
-    per capita consumption (aged 15 years and older) within a calendar year in litres
-    of pure alcohol
-3.6.1:
-  custodian_agency: World Health Organization (WHO)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-06-01.pdf
-  title: Death rate due to road traffic injuries
-3.7.1:
-  custodian_agency: Population Division, Department of Economic and Social Affairs
-    (DESA), United Nations Population, Fund (UNFPA)
-  definition: The percentage of women of reproductive age (15-49 years) who desire
-    either to have no (additional) children or to postpone the next child and who
-    are currently using a modern contraceptive method.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-07-01.pdf
-  title: Proportion of women of reproductive age (aged 15–49 years) who have their
-    need for family planning satisfied with modern methods
-3.7.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-07-02.pdf
-  title: Adolescent birth rate (aged 10–14 years; aged 15–19 years) per 1,000 women
-    in that age group
-3.8.1:
-  custodian_agency: World Health Organization, (WHO)
-  definition: Coverage of essential health services (defined as the average coverage
-    of essential services based on tracer interventions that include reproductive,
-    maternal, newborn and child health, infectious diseases, non-communicable diseases
-    and service capacity and access, among the general and the most disadvantaged
-    population).  The indicator is an index reported on a unitless scale of 0 to 100,
-    which is computed as the geometric mean of 14 tracer indicators of health service
-    coverage.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-08-01.pdf
-  title: Coverage of essential health services (defined as the average coverage of
-    essential services based on tracer interventions that include reproductive, maternal,
-    newborn and child health, infectious diseases, non-communicable diseases and service
-    capacity and access, among the general and the most disadvantaged population)
-3.8.2:
-  definition: Proportion of the population with large household expenditure on health
-    as a share of total household expenditure or income.   greater than 25% of total
-    household expenditure or income.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-08-02.pdf
-  title: Proportion of population with large household expenditures on health as a
-    share of total household expenditure or income
-3.9.1:
-  custodian_agency: World Health Organization (WHO)
-  definition: 'The mortality attributable to the joint effects of household and ambient
-    air pollution can be expressed as: Number of deaths, Death rate. Death rates are
-    calculated by dividing the number of deaths by the total population (or indicated
-    if a different population group is used, e.g. children under 5 years).  Evidence
-    from epidemiological studies have shown that exposure to air pollution is linked,
-    among others, to the important diseases taken into account in this estimate:  -
-    Acute respiratory infections in young children (estimated under 5 years of age);
-    - Cerebrovascular diseases (stroke) in adults (estimated above 25 years); - Ischaemic
-    heart diseases (IHD) in adults (estimated above 25 years); - Chronic obstructive
-    pulmonary disease (COPD) in adults (estimated above 25 years); and - Lung cancer
-    in adults (estimated above 25 years).'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-01.pdf
-  title: Mortality rate attributed to household and ambient air pollution
-3.9.2:
-  custodian_agency: World Health Organization (WHO)
-  definition: The mortality rate attributed to unsafe water, unsafe sanitation and
-    lack of hygiene (exposure to unsafe Water, Sanitation and Hygiene for All (WASH)
-    services) as defined as the number of deaths from unsafe water, unsafe sanitation
-    and lack of hygiene (exposure to unsafe WASH services) in a year, divided by the
-    population, and multiplied by 100,000.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-02.pdf
-  title: Mortality rate attributed to unsafe water, unsafe sanitation and lack of
-    hygiene (exposure to unsafe Water, Sanitation and Hygiene for All (WASH) services)
-3.9.3:
-  custodian_agency: World Health Organization (WHO)
-  definition: The mortality rate attributed to unintentional poisoning as defined
-    as the number of deaths of unintentional poisonings in a year, divided by the
-    population, and multiplied by 100 000.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-03.pdf
-  title: Mortality rate attributed to unintentional poisoning
-3.a.1:
-  definition: The indicator is defined as the percentage of the population aged 15
-    years and over who currently use any tobacco product (smoked and/or smokeless
-    tobacco) on a daily or non-daily basis.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0a-01.pdf
-  title: Age-standardized prevalence of current tobacco use among persons aged 15
-    years and older
-3.b.1:
-  custodian_agency: World Health Organization, (WHO), (UNICEF)
-  definition: 'Coverage of DTP containing vaccine (3rd dose): Percentage of surviving
-    infants who received the 3 doses of diphtheria and tetanus toxoid with pertussis
-    containing vaccine in a given year.  Coverage of Measles containing vaccine (2nd
-    dose): Percentage of children who received two dose of measles containing vaccine
-    according to nationally recommended schedule through routine immunization services.  Coverage
-    of Pneumococcal conjugate vaccine (last dose in the schedule): Percentage of surviving
-    infants who received the recommended doses of pneumococcal conjugate vaccine.   Coverage
-    of HPV vaccine (last dose in the schedule): Percentage of 15 years old girls received
-    the recommended doses of HPV vaccine.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0b-01.pdf
-  title: Proportion of the target population covered by all vaccines included in their
-    national programme
-3.b.2:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: Gross disbursements of total ODA from all donors to medical research
-    and basic health sectors.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0B-02.pdf
-  title: Total net official development assistance to medical research and basic health
-    sectors
-3.b.3:
-  title: Proportion of health facilities that have a core set of relevant essential
-    medicines available and affordable on a sustainable basis
-3.c.1:
-  custodian_agency: World Health Organization (WHO)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0C-01.pdf
-  title: Health worker density and distribution
-3.d.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0D-01.pdf
-  title: International Health Regulations (IHR) capacity and health emergency preparedness
-4.1.1:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: Percentage of children and young people in Grade 2 or 3 of primary education,
-    at the end of primary education and the end of lower secondary education achieving
-    at least a minimum proficiency level in (a) reading and (b) mathematics. The minimum
-    proficiency level will be measured relative to new common reading and mathematics
-    scales currently in development.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-01-01.pdf
-  title: 'Proportion of children and young people (a) in grades 2/3; (b) at the end of primary; and (c) at the end of lower secondary achieving at least a minimum proficiency level in (i) reading and (ii) mathematics, by sex'
-4.2.1:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: 'The proportion of children under 5 years of age who are developmentally
-    on track in health, learning and psychosocial well-being is currently being measured
-    by the percentage of children aged 36-59 months who are developmentally on-track
-    in at least three of the following four domains: literacy-numeracy, physical,
-    socio-emotional and learning.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-01.pdf
-  title: Proportion of children under 5 years of age who are developmentally on track
-    in health, learning and psychosocial well-being, by sex
-4.2.2:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: The participation rate in organized learning (one year before the official
-    primary entry age), by sex as defined as the percentage of children in the given
-    age range who participate in one or more organized learning programme, including
-    programmes which offer a combination of education and care. Participation in early
-    childhood and in primary education are both included. The age range will vary
-    by country depending on the official age for entry to primary education.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-02.pdf
-  title: Participation rate in organized learning (one year before the official primary
-    entry age), by sex
-4.3.1:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: The percentage of youth and adults in a given age range (e.g. 15-24
-    years, 25-64 years, etc.) participating in formal or non-formal education or training
-    in a given time period (e.g. last 12 months).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-03-01.pdf
-  title: Participation rate of youth and adults in formal and non-formal education
-    and training in the previous 12 months, by sex
-4.4.1:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: The proportion of youth and adults with information and communications
-    technology (ICT) skills, by type of skill as defined as the percentage of youth
-    (aged 15-24 years) and adults (aged 15 years and above) that have undertaken certain
-    computer-related activities in a given time period (e.g. last three months).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-04-01.pdf
-  title: Proportion of youth and adults with information and communications technology
-    (ICT) skills, by type of skill
-4.5.1:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: Parity indices require data for the specific groups of interest. They
-    represent the ratio of the indicator value for one group to that of the other.
-    Typically, the likely more disadvantaged group is placed in the numerator. A value
-    of exactly 1 indicates parity between the two groups.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-05-01.pdf
-  title: Parity indices (female/male, rural/urban, bottom/top wealth quintile and
-    others such as disability status, indigenous peoples and conflict-affected, as
-    data become available) for all education indicators on this list that can be disaggregated
-4.6.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-06-01.pdf
-  title: Proportion of population in a given age group achieving at least a fixed
-    level of proficiency in functional (a) literacy and (b) numeracy skills, by sex
-4.7.1:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: 'Extent to which (i) global citizenship education and (ii) education
-    for sustainable development, including gender equality and human rights, are mainstreamed
-    at all levels in: (a) national education policies, (b) curricula, (c) teacher
-    education and (d) student assessment'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-07-01.pdf
-  title: 'Extent to which (i) global citizenship education and (ii) education for sustainable development, including gender equality and human rights, are mainstreamed at all levels in (a) national education policies; (b) curricula; (c) teacher education; and (d) student assessment'
-4.a.1:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: The percentage of schools by level of education (primary education)
-    with access to the given facility or service.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0A-01.pdf
-  title: 'Proportion of schools with access to (a) electricity; (b) the Internet for pedagogical purposes; (c) computers for pedagogical purposes; (d) adapted infrastructure and materials for students with disabilities; (e) basic drinking water; (f) single-sex basic sanitation facilities; and (g) basic handwashing facilities (as per the WASH indicator definitions)'
-4.b.1:
-  definition: Gross disbursements of total ODA from all donors for scholarships.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0B-01.pdf
-  title: Volume of official development assistance flows for scholarships by sector
-    and type of study
-4.c.1:
-  custodian_agency: UNESCO Institute for Statistics (UNESCO-UIS)
-  definition: The percentage of teachers by level of education taught (pre-primary,
-    primary, lower secondary and upper secondary education) who have received at least
-    the minimum organized pedagogical teacher training pre-service and in-service
-    required for teaching at the relevant level in a given country
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0C-01.pdf
-  title: 'Proportion of teachers in: (a) pre-primary; (b) primary; (c) lower secondary; and (d) upper secondary education who have received at least the minimum organized teacher training (e.g. pedagogical training) pre-service or in-service required for teaching at the relevant level in a given country'
-5.1.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-01-01.pdf
-  title: Whether or not legal frameworks are in place to promote, enforce and monitor
-    equality and non‐discrimination on the basis of sex
-5.2.1:
-  custodian_agency: United Nations Entity for Gender Equality and the Empowerment
-    of Women (UN Women), United Nations Children's Fund (UNICEF), United Nations Statistics
-    Division (UNSD), World Health Organization (WHO), United Nations Population Fund
-    (UNFPA)
-  definition: This indicator measures the percentage of ever-partnered women and girls
-    aged 15 years and older who have experienced physical, sexual or psychological
-    violence by a current or former intimate partner, in the previous 12 months.  Definition
-    of violence against women and girls and of the forms of violence specified under
-    this indicator are presented in the next section (Concepts).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-02-01.pdf
-  title: Proportion of ever-partnered women and girls aged 15 years and older subjected
-    to physical, sexual or psychological violence by a current or former intimate
-    partner in the previous 12 months, by form of violence and by age
-5.2.2:
-  custodian_agency: United Nations Entity for Gender Equality and the Empowerment
-    of Women (UN Women), United Nations Children's Fund (UNICEF), United Nations Statistics
-    Division (UNSD), World Health Organization (WHO), United Nations Population Fund
-    (UNFPA)
-  definition: This indicator measures the percentage of women and girls aged 15 years
-    and older who have experienced sexual violence by persons other than an intimate
-    partner, in the previous 12 months.  Definition of sexual violence against women
-    and girls is presented in the next section (Concepts).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-02-02.pdf
-  title: Proportion of women and girls aged 15 years and older subjected to sexual
-    violence by persons other than an intimate partner in the previous 12 months,
-    by age and place of occurrence
-5.3.1:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: Proportion of women aged 20-24 years who were married or in a union
-    before age 15 and before age 18
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-03-01.pdf
-  title: Proportion of women aged 20–24 years who were married or in a union before
-    age 15 and before age 18
-5.3.2:
-  custodian_agency: United Nations Children's Fund (UNICEF)
-  definition: Proportion of girls and women aged 15-49 years who have undergone female
-    genital mutilation/cutting is currently being measured by the proportion of girls
-    aged 15-19 years who have undergone female genital mutilation/cutting
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-03-02.pdf
-  title: Proportion of girls and women aged 15–49 years who have undergone female
-    genital mutilation/cutting, by age
-5.4.1:
-  custodian_agency: UN Statistics Division (UNSD)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-04-01.pdf
-  title: Proportion of time spent on unpaid domestic and care work, by sex, age and
-    location
-5.5.1:
-  title: Proportion of seats held by women in (a) national parliaments and (b) local
-    governments
-5.5.1a:
-  custodian_agency: Inter-Parliamentary, Union (IPU)
-  definition: The proportion of seats held by women in (a) national parliaments, currently
-    as at 1 February of reporting year, is currently measured as the number of seats
-    held by women members in single or lower chambers of national parliaments, expressed
-    as a percentage of all occupied seats.  National parliaments can be bicameral
-    or unicameral. This indicator covers the single chamber in unicameral parliaments
-    and the lower chamber in bicameral parliaments. It does not cover the upper chamber
-    of bicameral parliaments. Seats are usually won by members in general parliamentary
-    elections. Seats may also be filled by nomination, appointment, indirect election,
-    rotation of members and by-election.  Seats refer to the number of parliamentary
-    mandates, or the number of members of parliament.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-01a.pdf
-5.5.1b:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-01b.pdf
-5.5.2:
-  custodian_agency: ILO
-  definition: 'This indicator refers to the proportion of females in the total number
-    of persons employed in managerial positions. It is recommended to use two different
-    measures jointly for this indicator: the share of females in (total) management
-    and the share of females in senior and middle management (thus excluding junior
-    management). The joint calculation of these two measures provides information
-    on whether women are more represented in junior management than in senior and
-    middle management, thus pointing to an eventual ceiling for women to access higher-level
-    management positions. In these cases, calculating only the share of women in (total)
-    management would be misleading, in that it would suggest that women hold positions
-    with more decision-making power and responsibilities than they actually do.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-02.pdf
-  title: Proportion of women in managerial positions
-5.6.1:
-  custodian_agency: United Nations Population Fund (UNFPA)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-06-01.pdf
-  title: Proportion of women aged 15–49 years who make their own informed decisions
-    regarding sexual relations, contraceptive use and reproductive health care
-5.6.2:
-  title: Number of countries with laws and regulations that guarantee full and equal
-    access to women and men aged 15 years and older to sexual and reproductive health
-    care, information and education
-5.a.1:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0A-01.pdf
-  title: (a) Proportion of total agricultural population with ownership or secure
-    rights over agricultural land, by sex; and (b) share of women among owners or
-    rights-bearers of agricultural land, by type of tenure
-5.a.2:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0a-02.pdf
-  title: Proportion of countries where the legal framework (including customary law)
-    guarantees women’s equal rights to land ownership and/or control
-5.a.2x:
-  definition: 'Indicator 5.a.2 collects all existing national policy objectives, draft
-    provisions, legal provisions and ownership and/or control.   ed as a legally recognised
-    right to acquire, to use and to transfer landed property.     The proxies used
-    to monitor Indicator 5.a.2 are widely recognised as good practices in strengthening   The
-    indicator captures the following four proxies:  a) Does the legal framework provide
-    for the establisand/or access to productive resources and services?  b) Is joint
-    titling of private property compulsory or encouraged through economic incentives
-    for married or unmarried couples, in accordance with national law?  c) In recognised
-    customary tenure systems, does the law facilitate the recording of all interests
-    in land (including use rights) of men and women?   The policy and legal instruments
-    covered include draft policy documents, formally adopted policy documents, draft
-    legislation, primary law, secondary legislation (see terminology section for detailed
-    explanation).  Nota bene: The proxies are intended to capture a range of different
-    regional contexts to reflect the universal scope of the Sustainable Development
-    Goals. As a result, Proxy c) may not be applicable to all countries.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0A-02X.pdf
-5.b.1:
-  custodian_agency: International Telecommunication Union (ITU)
-  definition: The proportion of individuals who own a mobile telephone, by sex is
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0B-01.pdf
-  title: Proportion of individuals who own a mobile telephone, by sex
-5.c.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0c-01.pdf
-  title: Proportion of countries with systems to track and make public allocations
-    for gender equality and women’s empowerment
-6.1.1:
-  custodian_agency: World Health Organization (WHO),  United Nations Children's Fund
-    (UNICEF)
-  definition: 'Proportion of population using safely managed drinking water services
-    is currently being measured by the proportion of population using an improved
-    basic drinking water source which is located on premises, drinking water sources
-    include: piped water into dwelling, yard or plot; public taps or standpipes; boreholes
-    or tubewells; protected dug wells; protected springs; packaged water; delivered
-    water and rainwater.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-01-01.pdf
-  title: Proportion of population using safely managed drinking water services
-6.2.1:
-  custodian_agency: World Health Organization (WHO),  United Nations Children's Fund
-    (UNICEF)
-  definition: 'The Proportion of population using safely managed sanitation services,
-    including a hand-washing facility with soap and water is currently being measured
-    by the proportion of the population using a basic sanitation facility which is
-    not shared with other households and where excreta is safely disposed in situ
-    or treated off-sanitation facilities include: flush or pour flush toilets to sewer
-    systems, septic tanks or pit latrines, ventilated improved pit latrines, pit latrines
-    with a slab, and composting toilets.   Population with a basic handwashing facility:
-    a device to contain, transport or regulate the flow of water to facilitate handwashing
-    with soap and water in the household.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-02-01.pdf
-  title: Proportion of population using (a) safely managed sanitation services and
-    (b) a hand-washing facility with soap and water
-6.3.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-03-01.pdf
-  title: Proportion of wastewater safely treated
-6.3.2:
-  custodian_agency: UN Environment, (United Nations Environment Programme)
-  definition: The indicator is defined as the proportion of water bodies in the country
-    that have good ambient water quality. Ambient water quality refers to natural,
-    untreated water in rivers, lakes and groundwaters and represents a combination
-    of natural influences together with the impacts of all anthropogenic activities.
-    The indicator relies on water quality data derived from in situ measurements and
-    the analysis of samples collected from surface and groundwaters. Water quality
-    is assessed by means of core physical and chemical parameters that reflect natural
-    water quality related to climatological and geological factors, together with
-    major impacts on water quality. The continuous monitoring of all surface and groundwaters
-    is economically unfeasible and not required to sufficiently characterize the status
-    of ambient water quality in a country. Therefore, countries select river, lake
-    and groundwater bodies that are representative and significant for the assessment
-    and management of water quality to monitor and report on indicator 6.3.2. The
-    quality status of individual water bodies is classified based on the compliance
-    of the available water quality monitoring data for the core parameters with target
-    values defined by the country. The indicator is computed as the proportion of
-    the number of water bodies classified as having good quality (i.e. with at least
-    80 % compliance) to the total number of assessed water bodies, expressed as a
-    percentage.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-03-02.pdf
-  title: Proportion of bodies of water with good ambient water quality
-6.4.1:
-  definition: 'The change in water use efficiency over time (CWUE). The change in
-    the ratio of the value added to the volume of water use, over time.  Water Use
-    Efficiency (WUE) is defined as the volume of water used divided by the value added
-    of a given major sector1. Following ISIC 4 coding, sectors are defined as: 1.  2.
-    mining and quarrying; manufacturing; electricity, gas, steam and air conditioning
-    supply; constructions (ISIC B, C,  3. all the service sectors (ISIC E and ISIC
-    G-  The unit of the indicator is expressed in Value/Volume, commonly USD/m3.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-04-01.pdf
-  title: Change in water-use efficiency over time
-6.4.2:
-  custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
-  definition: 'The level of water stress: freshwater withdrawal as a proportion of
-    available freshwater resources is the ratio between total freshwater withdrawn
-    by all major sectors and total renewable freshwater resources, after taking into
-    account environmental water requirements. Main sectors, as defined by ISIC standards,
-    include agriculture; forestry and fishing; manufacturing; electricity industry;
-    and services. This indicator is also known as water withdrawal intensity.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-04-02.pdf
-  title: 'Level of water stress: freshwater withdrawal as a proportion of available
-    freshwater resources'
-6.5.1:
-  custodian_agency: United Nations Environment Programme (UNEP)
-  definition: The indicator degree of implementation of Integrated Water Resources
-    Management (IWRM), measured in per cent (%) from 0 (implementation not yet started)
-    to 100 (fully implemented) is currently being measured in terms of different stages
-    of development and implementation of Integrated Water Resources Management (IWRM).   The
-    definition of IWRM is based on an internationally agreed definition, and is universally
-    applicable. e coordinated development and management of water, land and related
-    resources in order to maximise economic and (GWP 2010).   The method builds on
-    official UN IWRM status reporting, from 2008 and 2012, of the Johannesburg Plan
-    of Implementation from the UN World Summit for Sustainable Development (1992).
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-05-01.pdf
-  title: Degree of integrated water resources management implementation (0–100)
-6.5.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-05-02.pdf
-  title: Proportion of transboundary basin area with an operational arrangement for
-    water cooperation
-6.6.1:
-  title: Change in the extent of water-related ecosystems over time
-6.6.1a:
-  custodian_agency: UN Environment (United Nations Environment Programme)
-  definition: 'The indicator includes five categories: 1) vegetated wetlands, 2) rivers
-    and estuaries, 3) lakes, 4) aquifers, and 5) artificial waterbodies. For purposes
-    of this methodology, the text refers only to these five ecosystem category terminologies.
-    To address its complexity, Indicator 6.6.1 has been divided into 5 Sub-Indicators
-    to capture the various data sources and methodologies required for monitoring
-    components of the Indicator. Data sources come from a combination of ground sampling
-    and earth observations. Depending on the type of ecosystem and the type of extent
-    being measured, the data collection methodology can also differ greatly. A progressive
-    monitoring approach with two levels is proposed:  Level 1: 2 Sub-Indicators based
-    on globally available data from earth observations which will be validated by
-    countries against their own methodologies and datasets:   Sub-Indicator 1  spatial
-    extent of water-related ecosystems   Sub-Indicator 2  water quality of lakes and
-    artificial water bodies Level 2: Data collected by countries through 3 Sub-Indicators:  Sub-Indicator
-    3  quantity of water (discharge) in rivers and estuaries  Sub-Indicator 4  water
-    quality imported from SDG Indicator 6.3.2   Sub-Indicator 5  quantity of groundwater
-    within aquifers  A full methodoloMonitoring Methodology for SDG Indicator 6.6.1'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-06-01a.pdf
-6.6.1b:
-  custodian_agency: Secretariat of the Ramsar Convention on Wetlands
-  definition: 'Extent of wetlands: this term can be defined as the surface area of
-    wetlands. It is measured in km2 or hectares. It is expected that the surface reported
-    by countries corresponds to the 2017 situation; if not, the reference year should
-    be indicated.   Change in the extent of wetlands: this term refers to the percentage
-    change in area of wetlands from a baseline reference. For reporting such change,
-    the previous extent, if known, and the period over which the change has taken
-    place should be specified.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-06-01b.pdf
-6.a.1:
-  custodian_agency: World Health Organization (WHO),  United Nations Environment Programme
-    (UNEP),  Organisation for Economic Co-operation and Development (OECD)
-  definition: Amount of water- and sanitation-related official development assistance
-    that is part of a government-coordinated spending plan is defined as the proportion
-    of total water and sanitation-related Official Development Assistance (ODA) disbursements
-    that are included in the government budget.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-0A-01.pdf
-  title: Amount of water- and sanitation-related official development assistance that
-    is part of a government-coordinated spending plan
-6.b.1:
-  custodian_agency: World Health Organization (WHO),  United Nations Environment Programme
-    (UNEP),  Organisation for Economic Co-operation and Development (OECD)
-  definition: The indicator assesses the percentage of local administrative units
-    (as defined by the national government) that have an established and operational
-    mechanism by which individuals and communities can meaningfully contribute to
-    decisions and directions about water and sanitation management.  The indicator
-    Proportion of local administrative units with established and operational policies
-    and procedures for participation of local communities in water and sanitation
-    management is currently being measured by the Proportion of countries with clearly
-    defined procedures in law or policy for participation by service users/communities
-    in planning program in water and sanitation management, and hygiene promotion
-    and the Proportion of countries with high level of users/communities participating
-    in planning programs in water and sanitation management, and hygiene promotion.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-0B-01.pdf
-  title: Proportion of local administrative units with established and operational
-    policies and procedures for participation of local communities in water and sanitation
-    management
-7.1.1:
-  custodian_agency: World Bank (WB)
-  definition: Proportion of population with access to electricity is the percentage
-    of population with access to electricity.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-01-01.pdf
-  title: Proportion of population with access to electricity
-7.1.2:
-  custodian_agency: World Health Organization (WHO)
-  definition: 'Proportion of population with primary reliance on clean fuels and technology  is
-    calculated as the number of people using clean fuels and technologies for cooking,
-    heating and lighting divided by total population reporting that any cooking, heating
-    or lighting, expressed as percentage. emission rate targets and specific fuel
-    recommendations (i.e. against unprocessed coal and kerosene) included in the normative
-    guidance WHO guidelines for indoor air quality: household fuel combustion.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-01-02.pdf
-  title: Proportion of population with primary reliance on clean fuels and technology
-7.2.1:
-  custodian_agency: International Energy Agency (IEA) , United Nations Statistics
-    Division (UNSD) , United Nations' inter-agency Mechanism on Energy (UN Energy)
-    , International Renewable Energy Agency (IRENA)
-  definition: The renewable energy share in total final consumption is the percentage
-    of final consumption of energy that is derived from renewable resources.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-02-01.pdf
-  title: Renewable energy share in the total final energy consumption
-7.3.1:
-  custodian_agency: International Energy Agency (IEA),  United Nations Statistics
-    Division (UNSD),  United Nations' Inter-agency Mechanism on Energy (UN Energy),  SE4ALL
-    Global Tracking Framework Consortium (SE4ALL Global Tracking Framework Consortium)
-  definition: Energy intensity is defined as the energy supplied to the economy pet
-    unit value of economic output.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-03-01.pdf
-  title: Energy intensity measured in terms of primary energy and GDP
-7.a.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-    and International Renewable Energy Agency (IRENA)
-  definition: 'The flows are covered through two complementary sources.  OECD: The
-    flows covered by the OECD are defined as all official loans, grants and equity
-    investments received by countries on the DAC List of ODA Recipients from foreign
-    governments and multilateral agencies, for the purpose of clean energy research
-    and development and renewable energy production, including in hybrid systems extracted
-    from the OECD/DAC Creditor Reporting System (CRS) with the following sector codes:   23210
-    Energy generation, renewable sources  multiple technologies - Renewable energy
-    generation programmes that cannot be attributed to one single technology (codes
-    23220 through 23280 below). Fuelwood/charcoal production should be included under
-    forestry 31261.   23220 Hydro-electric power plants - Including energy generating
-    river barges.   23230 Solar energy - Including photo-voltaic cells, solar thermal
-    applications and solar heating.   23240 Wind energy - Wind energy for water lifting
-    and electric power generation.   23250 Marine energy - Including ocean thermal
-    energy conversion, tidal and wave power.   23260 Geothermal energy - Use of geothermal
-    energy for generating electric power or directly as heat for agriculture, etc.   23270-
-    Biofuel-fired power plants Use of solids and liquids produced from biomass for
-    direct power generation. Also includes biogases from anaerobic fermentation (e.g.
-    landfill gas, sewage sludge gas, fermentation of energy crops and manure) and
-    thermal processes (also known as syngas); waste fired power plants making use
-    of biodegradable municipal waste (household waste and waste from companies and
-    public services that resembles household waste, collected at installations specifically
-    designed for their disposal with recovery of combustible liquids, gases or heat).
-    See code 23360 for non-renewable waste-fired power plants.  Research and development
-    of energy efficiency technologies and measures is captured under CRS sector code
-    23182 on Energy research. The above flows also include technical assistance provided
-    to support production, research and development as defined above. Last updated:
-    12 February 2018  IRENA: The flows covered by IRENA are defined as all additional
-    loans, grants and equity investments received by developing countries (defined
-    as countries in developing regions, as listed in the UN M49 composition of regions)
-    from all foreign governments, multilateral agencies and additional development
-    finance institutions (including export credits, where available) for the purpose
-    of clean energy research and development and renewable energy production, including
-    in hybrid systems. These additional flows cover the same technologies and other
-    activities (research and development, technical assistance, etc.) as listed above
-    and exclude all flows extracted from the OECD/DAC CRS.'
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-0a-01.pdf
-  title: International financial flows to developing countries in support of clean
-    energy research and development and renewable energy production, including in
-    hybrid systems
-7.b.1:
-  title: Investments in energy efficiency as a proportion of GDP and the amount of
-    foreign direct investment in financial transfer for infrastructure and technology
-    to sustainable development services
-8.1.1:
-  custodian_agency: United Nations Statistics Division (UNSD)
-  definition: Annual growth rate of real Gross Domestic Product (GDP) per capita is
-    calculated as the percentage change in the real GDP per capita between two consecutive
-    years. Real GDP per capita is calculated by dividing GDP at constant prices by
-    the population of a country or area. The data for real GDP are measured in constant
-    US dollars to facilitate the calculation of regional and global aggregates.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-01-01.pdf
-  title: Annual growth rate of real GDP per capita
-8.10.1:
-  custodian_agency: International Monetary Fund (STAFI -, Financial Access Survey,
-    Team)
-  definition: The number of commercial bank branches per 100,000 adults The number
-    of automated teller machines (ATMs) per 100,000 adults
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-10-01.pdf
-  title: (a) Number of commercial bank branches per 100,000 adults and (b) number
-    of automated teller machines (ATMs) per 100,000 adults
-8.10.2:
-  definition: The percentage of adults (ages 15+) who report having an account (by
-    themselves or together with someone else) at a bank or another type of financial
-    institution or personally using a mobile money service in the past 12 months.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-10-02.pdf
-  title: Proportion of adults (15 years and older) with an account at a bank or other
-    financial institution or with a mobile-money-service provider
-8.2.1:
-  custodian_agency: ILO
-  definition: Annual growth rate of real GDP per employed person conveys the annual
-    percentage change in real Gross Domestic Product per employed person.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-02-01.pdf
-  title: Annual growth rate of real GDP per employed person
-8.3.1:
-  custodian_agency: ILO
-  definition: This indicator presents the share of non-agricultural employment which
-    is classified as informal employment.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-03-01.pdf
-  title: Proportion of informal employment in non‐agriculture employment, by sex
-8.4.1:
-  custodian_agency: United Nations Environment Programme (UNEP)
-  definition: Material Footprint (MF) is the attribution of global material extraction
-    to domestic final demand of a country. The total material footprint is the sum
-    of the material footprint for biomass, fossil fuels, metal ores and non-metal
-    ores.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-01.pdf
-  title: Material footprint, material footprint per capita, and material footprint
-    per GDP
-8.4.2:
-  custodian_agency: United Nations Environment Programme (UNEP)
-  definition: Domestic Material Consumption (DMC) is a standard material flow accounting
-    (MFA) indicator and reports the apparent consumption of materials in a national
-    economy.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-02.pdf
-  title: Domestic material consumption, domestic material consumption per capita,
-    and domestic material consumption per GDP
-8.5.1:
-  custodian_agency: International Labour Organisation (ILO)
-  definition: This indicator provides information on the mean hourly earnings from
-    paid employment of employees by sex, occupation, age and disability status.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-05-01.pdf
-  title: Average hourly earnings of female and male employees, by occupation, age
-    and persons with disabilities
-8.5.2:
-  custodian_agency: ILO
-  definition: The unemployment rate conveys the percentage of persons in the labour
-    force who are unemployed.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-05-02.pdf
-  title: Unemployment rate, by sex, age and persons with disabilities
-8.6.1:
-  custodian_agency: ILO
-  definition: This indicator conveys the proportion of youth (aged 15-24 years) not
-    in education, employment or training (also known as "the youth NEET rate").
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-06-01.pdf
-  title: Proportion of youth (aged 15–24 years) not in education, employment or training
-8.7.1:
-  custodian_agency: United Nations Children's Fund (UNICEF) , International Labour
-    Organization (ILO)
-  definition: The number of children engaged in child labour corresponds to the number
-    of children reported to be in child labour during the reference period (usually
-    the week prior to the survey). The proportion of children in child labour is calculated
-    as the number of children in child labour divided by the total number of children
-    in the population.  For the purposes of this indicator, children include all persons
-    aged 5 to 17. This indicator is disaggregated by sex and age group (age bands
-    5-14 and 15-17)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-07-01.pdf
-  title: Proportion and number of children aged 5–17 years engaged in child labour,
-    by sex and age
-8.8.1:
-  custodian_agency: ILO
-  definition: The frequency rates of fatal and non-fatal occupational injuries provide
-    information on the number of cases of fatal and non-fatal occupational injury
-    per hours worked by the concerned population during the reference period. It is
-    a measure of the risk of having a fatal or a non-fatal occupational injury based
-    on the duration of exposure to adverse work-related factors.  The incidence rates
-    of fatal and non-fatal occupational injuries provide information on the number
-    of cases of fatal and non-fatal occupational injury per workers in the reference
-    group during the reference period. It is a measure of the personal likelihood
-    of the workers in the reference group of suffering from work-related injuries.  For
-    the purposes of international reporting on the SDG indicators, incidence rates
-    are used, even though the indicator title of 8.8.1 calls for the use of frequency
-    rates, as common practices around the world and data availability favour incidence
-    rates.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-08-01.pdf
-  title: Frequency rates of fatal and non-fatal occupational injuries, by sex and
-    migrant status
-8.8.2:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-08-02.pdf
-  title: Level of national compliance with labour rights (freedom of association and collective bargaining) based on International Labour Organization (ILO) textual sources and national legislation, by sex and migrant status
-8.9.1:
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-09-01.pdf
-  title: Tourism direct GDP as a proportion of total GDP and in growth rate
-8.9.2:
-  title: Proportion of jobs in sustainable tourism industries out of total tourism
-    jobs
-8.a.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: Aid for Trade commitments and disbursements is the gross disbursements
-    and commitments of total Official Development Assistance (ODA) from all donors
-    for aid for trade.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-0A-01.pdf
-  title: Aid for Trade commitments and disbursements
-8.b.1:
-  title: Existence of a developed and operationalized national strategy for youth
-    employment, as a distinct strategy or as part of a national employment strategy
-9.1.1:
-  title: Proportion of the rural population who live within 2 km of an all-season
-    road
-9.1.2:
-  custodian_agency: International Civil Aviation Organization (ICAO)
-  definition: Passenger and freight volumes is the sum of the passenger and freight
-    volumes reported for the air carriers in terms of number of people and metric
-    tonnes of cargo respectively.  The International Transport Forum (ITF) collects
-    data on transport (rail and road) statistics on annual basis from all its Member
-    countries.  Data are collected from Transport Ministries, statistical offices
-    and other institution designated as official data source. Although there are clear
-    definitions for all the terms used in this survey, countries might have different
-    methodologies to calculate tonne-kilometres and passenger-kilometres. Methods
-    could be based on traffic or mobility surveys, use very different sampling methods
-    and estimating techniques which could affect the comparability of their statistics.  ITF
-    (2016) Trends in the Transport Sector
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-01-02.pdf
-  title: Passenger and freight volumes, by mode of transport
-9.2.1:
-  custodian_agency: United Nations Industrial Development Organization (UNIDO)
-  definition: Manufacturing value added (MVA) as a proportion of gross domestic product
-    (GDP) is a ratio between MVA and GDP, both reported in constant 2010 USD.  MVA
-    per capita is calculated by dividing MVA in constant 2010 USD by population of
-    a country or area.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-01.pdf
-  title: Manufacturing value added as a proportion of GDP and per capita
-9.2.2:
-  custodian_agency: United Nations Industrial Development Organization (UNIDO)
-  definition: The indicator is represented by the share of manufacturing employment
-    in total employment.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-02.pdf
-  title: Manufacturing employment as a proportion of total employment
-9.3.1:
-  custodian_agency: United Nations Industrial Development Organization (UNIDO)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-03-01.pdf
-  title: Proportion of small-scale industries in total industry value added
-9.3.2:
-  custodian_agency: United Nations Industrial Development Organization (UNIDO)
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-03-02.pdf
-  title: Proportion of small-scale industries with a loan or line of credit
-9.4.1:
-  definition: Carbon dioxide (here after, CO<sub>2</sub>) emissions per unit value added is an
-    indicator computed as ratio between CO<sub>2</sub> emissions from fuel combustion and the
-    value added of associated economic activities. The indicator can be computed for
-    the whole economy (total CO<sub>2</sub> emissions/GDP) or for specific sectors, notably the
-    manufacturing sector (CO<sub>2</sub> emissions from manufacturing industries per manufacturing
-    value added (MVA).   CO<sub>2</sub> emissions per unit of GDP are expressed in kilogrammes
-    of CO<sub>2</sub> per USD constant 2010 PPP GDP. CO<sub>2</sub> emissions from manufacturing industries
-    per unit of MVA are measured in kilogrammes of CO<sub>2</sub> equivalent per unit of MVA
-    in constant 2010 USD.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-04-01.pdf
-  title: CO<sub>2</sub> emission per unit of value added
-9.5.1:
-  custodian_agency: United Nations Educational, Scientific and Cultural Organization
-    (UNESCO)
-  definition: Research and development (R&D) expenditure as a proportion of Gross
-    Domestic Product (GDP) is the amount of R&D expenditure divided by the total output
-    of the economy.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-01.pdf
-  title: Research and development expenditure as a proportion of GDP
-9.5.2:
-  custodian_agency: United Nations Educational, Scientific and Cultural Organization
-    (UNESCO)
-  definition: The researchers (in full-time equivalent) per million inhabitants is
-    a direct measure of the number of research and development workers per 1 million
-    people.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-02.pdf
-  title: Researchers (in full-time equivalent) per million inhabitants
-9.a.1:
-  custodian_agency: Organisation for Economic Co-operation and Development (OECD)
-  definition: Gross disbursements of total ODA and other official flows from all donors
-    in support of infrastructure.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-0A-01.pdf
-  title: Total official international support (official development assistance plus
-    other official flows) to infrastructure
-9.b.1:
-  custodian_agency: United Nations Industrial Development Organization (UNIDO)
-  definition: The proportion of medium and high-tech industry (MHT hereafter) value
-    added in total value added of manufacturing (MVA hereafter) is a ratio value between
-    the value added of MHT industry and MVA.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-0B-01.pdf
-  title: Proportion of medium and high-tech industry value added in total value added
-9.c.1:
-  custodian_agency: International Telecommunication Union (ITU)
-  definition: Proportion of population covered by a mobile network, broken down by
-    technology, refers to the percentage of inhabitants living within range of a mobile-cellular
-    signal, irrespective of whether or not they are mobile phone subscribers or users.
-    This is calculated by dividing the number of inhabitants within range of a mobile-cellular
-    signal by the total population and multiplying by 100.
-  metadata_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-0C-01.pdf
-  title: Proportion of population covered by a mobile network, by technology
+1.1.1-title: Proportion of population below the international poverty line, by sex,
+  age, employment status and geographical location (urban/rural)
+1.2.1-title: Proportion of population living below the national poverty line, by sex
+  and age
+1.2.2-title: Proportion of men, women and children of all ages living in poverty in
+  all its dimensions according to national definitions
+1.3.1-title: Proportion of population covered by social protection floors/systems,
+  by sex, distinguishing children, unemployed persons, older persons, persons with
+  disabilities, pregnant women, newborns, work-injury victims and the poor and the
+  vulnerable
+1.4.1-title: Proportion of population living in households with access to basic services
+1.4.2-title: Proportion of total adult population with secure tenure rights to land,
+  (a) with legally recognized documentation, and (b) who perceive their rights to
+  land as secure, by sex and type of tenure
+1.5.1-title: Number of deaths, missing persons and directly affected persons attributed
+  to disasters per 100,000 population
+1.5.2-title: Direct economic loss attributed to disasters in relation to global gross
+  domestic product (GDP)
+1.5.3-title: Number of countries that adopt and implement national disaster risk reduction
+  strategies in line with the Sendai Framework for Disaster Risk Reduction 2015–2030
+1.5.4-title: Proportion of local governments that adopt and implement local disaster
+  risk reduction strategies in line with national disaster risk reduction strategies
+1.a.1-title: Proportion of domestically generated resources allocated by the government
+  directly to poverty reduction programmes
+1.a.2-title: Proportion of total government spending on essential services (education,
+  health and social protection)
+1.a.3-title: Sum of total grants and non-debt-creating inflows directly allocated
+  to poverty reduction programmes as a proportion of GDP
+1.b.1-title: Proportion of government recurrent and capital spending to sectors that
+  disproportionately benefit women, the poor and vulnerable groups
+10.1.1-title: Growth rates of household expenditure or income per capita among the
+  bottom 40 per cent of the population and the total population
+10.2.1-title: Proportion of people living below 50 per cent of median income, by sex,
+  age and persons with disabilities
+10.3.1-title: Proportion of population reporting having personally felt discriminated
+  against or harassed in the previous 12 months on the basis of a ground of discrimination
+  prohibited under international human rights law
+10.4.1-title: Labour share of GDP, comprising wages and social protection transfers
+10.5.1-title: Financial Soundness Indicators
+10.6.1-title: Proportion of members and voting rights of developing countries in international
+  organizations
+10.7.1-title: Recruitment cost borne by employee as a proportion of yearly income
+  earned in country of destination
+10.7.2-title: Number of countries that have implemented well-managed migration policies
+10.a.1-title: Proportion of tariff lines applied to imports from least developed countries
+  and developing countries with zero-tariff
+10.b.1-title: Total resource flows for development, by recipient and donor countries
+  and type of flow (e.g. official development assistance, foreign direct investment
+  and other flows)
+10.c.1-title: Remittance costs as a proportion of the amount remitted
+11.1.1-title: Proportion of urban population living in slums, informal settlements
+  or inadequate housing
+11.2.1-title: Proportion of population that has convenient access to public transport,
+  by sex, age and persons with disabilities
+11.3.1-title: Ratio of land consumption rate to population growth rate
+11.3.2-title: Proportion of cities with a direct participation structure of civil
+  society in urban planning and management that operate regularly and democratically
+11.4.1-title: Total expenditure (public and private) per capita spent on the preservation,
+  protection and conservation of all cultural and natural heritage, by type of heritage
+  (cultural, natural, mixed and World Heritage Centre designation), level of government
+  (national, regional and local/municipal), type of expenditure (operating expenditure/investment)
+  and type of private funding (donations in kind, private non-profit sector and sponsorship)
+11.5.1-title: Number of deaths, missing persons and directly affected persons attributed
+  to disasters per 100,000 population
+11.5.2-title: Direct economic loss in relation to global GDP, damage to critical infrastructure
+  and number of disruptions to basic services, attributed to disasters
+11.6.1-title: Proportion of urban solid waste regularly collected and with adequate
+  final discharge out of total urban solid waste generated, by cities
+11.6.2-title: Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10)
+  in cities (population weighted)
+11.7.1-title: Average share of the built-up area of cities that is open space for
+  public use for all, by sex, age and persons with disabilities
+11.7.2-title: Proportion of persons victim of physical or sexual harassment, by sex,
+  age, disability status and place of occurrence, in the previous 12 months
+11.a.1-title: Proportion of population living in cities that implement urban and regional
+  development plans integrating population projections and resource needs, by size
+  of city
+11.b.1-title: Number of countries that adopt and implement national disaster risk
+  reduction strategies in line with the Sendai Framework for Disaster Risk Reduction
+  2015–2030
+11.b.2-title: Proportion of local governments that adopt and implement local disaster
+  risk reduction strategies in line with national disaster risk reduction strategies
+11.c.1-title: Proportion of financial support to the least developed countries that
+  is allocated to the construction and retrofitting of sustainable, resilient and
+  resource-efficient buildings utilizing local materials
+12.1.1-title: Number of countries with sustainable consumption and production (SCP)
+  national action plans or SCP mainstreamed as a priority or a target into national
+  policies
+12.2.1-title: Material footprint, material footprint per capita, and material footprint
+  per GDP
+12.2.2-title: Domestic material consumption, domestic material consumption per capita,
+  and domestic material consumption per GDP
+12.3.1-title: Global food loss index
+12.4.1-title: Number of parties to international multilateral environmental agreements
+  on hazardous waste, and other chemicals that meet their commitments and obligations
+  in transmitting information as required by each relevant agreement
+12.4.2-title: Hazardous waste generated per capita and proportion of hazardous waste
+  treated, by type of treatment
+12.5.1-title: National recycling rate, tons of material recycled
+12.6.1-title: Number of companies publishing sustainability reports
+12.7.1-title: Number of countries implementing sustainable public procurement policies
+  and action plans
+12.8.1-title: Extent to which (i) global citizenship education and (ii) education
+  for sustainable development (including climate change education) are mainstreamed
+  in (a) national education policies; (b) curricula; (c) teacher education; and (d)
+  student assessment
+12.a.1-title: Amount of support to developing countries on research and development
+  for sustainable consumption and production and environmentally sound technologies
+12.b.1-title: Number of sustainable tourism strategies or policies and implemented
+  action plans with agreed monitoring and evaluation tools
+12.c.1-title: Amount of fossil-fuel subsidies per unit of GDP (production and consumption)
+  and as a proportion of total national expenditure on fossil fuels
+13.1.1-title: Number of deaths, missing persons and directly affected persons attributed
+  to disasters per 100,000 population
+13.1.2-title: Number of countries that adopt and implement national disaster risk
+  reduction strategies in line with the Sendai Framework for Disaster Risk Reduction
+  2015–2030
+13.1.3-title: Proportion of local governments that adopt and implement local disaster
+  risk reduction strategies in line with national disaster risk reduction strategies
+13.2.1-title: Number of countries that have communicated the establishment or operationalization
+  of an integrated policy/strategy/plan which increases their ability to adapt to
+  the adverse impacts of climate change, and foster climate resilience and low greenhouse
+  gas emissions development in a manner that does not threaten food production (including
+  a national adaptation plan, nationally determined contribution, national communication,
+  biennial update report or other)
+13.3.1-title: Number of countries that have integrated mitigation, adaptation, impact
+  reduction and early warning into primary, secondary and tertiary curricula
+13.3.2-title: Number of countries that have communicated the strengthening of institutional,
+  systemic and individual capacity-building to implement adaptation, mitigation and
+  technology transfer, and development actions
+13.a.1-title: Mobilized amount of United States dollars per year between 2020 and
+  2025 accountable towards the $100 billion commitment
+13.b.1-title: Number of least developed countries and small island developing States
+  that are receiving specialized support, and amount of support, including finance,
+  technology and capacity-building, for mechanisms for raising capacities for effective
+  climate change-related planning and management, including focusing on women, youth
+  and local and marginalized communities
+14.1.1-title: Index of coastal eutrophication and floating plastic debris density
+14.2.1-title: Proportion of national exclusive economic zones managed using ecosystem-based
+  approaches
+14.3.1-title: Average marine acidity (pH) measured at agreed suite of representative
+  sampling stations
+14.4.1-title: Proportion of fish stocks within biologically sustainable levels
+14.5.1-title: Coverage of protected areas in relation to marine areas
+14.6.1-title: Progress by countries in the degree of implementation of international
+  instruments aiming to combat illegal, unreported and unregulated fishing
+14.7.1-title: Sustainable fisheries as a proportion of GDP in small island developing
+  States, least developed countries and all countries
+14.a.1-title: Proportion of total research budget allocated to research in the field
+  of marine technology
+14.b.1-title: Progress by countries in the degree of application of a legal/regulatory/policy/institutional
+  framework which recognizes and protects access rights for small-scale fisheries
+14.c.1-title: Number of countries making progress in ratifying, accepting and implementing
+  through legal, policy and institutional frameworks, ocean-related instruments that
+  implement international law, as reflected in the United Nations Convention on the
+  Law of the Sea, for the conservation and sustainable use of the oceans and their
+  resources
+15.1.1-title: Forest area as a proportion of total land area
+15.1.2-title: Proportion of important sites for terrestrial and freshwater biodiversity
+  that are covered by protected areas, by ecosystem type
+15.2.1-title: Progress towards sustainable forest management
+15.3.1-title: Proportion of land that is degraded over total land area
+15.4.1-title: Coverage by protected areas of important sites for mountain biodiversity
+15.4.2-title: Mountain Green Cover Index
+15.5.1-title: Red List Index
+15.6.1-title: Number of countries that have adopted legislative, administrative and
+  policy frameworks to ensure fair and equitable sharing of benefits
+15.7.1-title: Proportion of traded wildlife that was poached or illicitly trafficked
+15.8.1-title: Proportion of countries adopting relevant national legislation and adequately
+  resourcing the prevention or control of invasive alien species
+15.9.1-title: Progress towards national targets established in accordance with Aichi
+  Biodiversity Target 2 of the Strategic Plan for Biodiversity 2011–2020
+15.a.1-title: Official development assistance and public expenditure on conservation
+  and sustainable use of biodiversity and ecosystems
+15.b.1-title: Official development assistance and public expenditure on conservation
+  and sustainable use of biodiversity and ecosystems
+15.c.1-title: Proportion of traded wildlife that was poached or illicitly trafficked
+16.1.1-title: Number of victims of intentional homicide per 100,000 population, by
+  sex and age
+16.1.2-title: Conflict-related deaths per 100,000 population, by sex, age and cause
+16.1.3-title: Proportion of population subjected to (a) physical violence, (b) psychological
+  violence and (c) sexual violence in the previous 12 months
+16.1.4-title: Proportion of population that feel safe walking alone around the area
+  they live
+16.10.1-title: Number of verified cases of killing, kidnapping, enforced disappearance,
+  arbitrary detention and torture of journalists, associated media personnel, trade
+  unionists and human rights advocates in the previous 12 months
+16.10.2-title: Number of countries that adopt and implement constitutional, statutory
+  and/or policy guarantees for public access to information
+16.2.1-title: Proportion of children aged 1–17 years who experienced any physical
+  punishment and/or psychological aggression by caregivers in the past month
+16.2.2-title: Number of victims of human trafficking per 100,000 population, by sex,
+  age and form of exploitation
+16.2.3-title: Proportion of young women and men aged 18–29 years who experienced sexual
+  violence by age 1
+16.3.1-title: Proportion of victims of violence in the previous 12 months who reported
+  their victimization to competent authorities or other officially recognized conflict
+  resolution mechanisms
+16.3.2-title: Unsentenced detainees as a proportion of overall prison population
+16.4.1-title: Total value of inward and outward illicit financial flows (in current
+  United States dollars)
+16.4.2-title: Proportion of seized, found or surrendered arms whose illicit origin
+  or context has been traced or established by a competent authority in line with
+  international instruments
+16.5.1-title: Proportion of persons who had at least one contact with a public official
+  and who paid a bribe to a public official, or were asked for a bribe by those public
+  officials, during the previous 12 months
+16.5.2-title: Proportion of businesses that had at least one contact with a public
+  official and that paid a bribe to a public official, or were asked for a bribe by
+  those public officials during the previous 12 months
+16.6.1-title: Primary government expenditures as a proportion of original approved
+  budget, by sector (or by budget codes or similar)
+16.6.2-title: Proportion of population satisfied with their last experience of public
+  services
+16.7.1-title: Proportions of positions (by sex, age, persons with disabilities and
+  population groups) in public institutions (national and local legislatures, public
+  service, and judiciary) compared to national distributions
+16.7.2-title: Proportion of population who believe decision-making is inclusive and
+  responsive, by sex, age, disability and population group
+16.8.1-title: Proportion of members and voting rights of developing countries in international
+  organizations
+16.9.1-title: Proportion of children under 5 years of age whose births have been registered
+  with a civil authority, by age
+16.a.1-title: Existence of independent national human rights institutions in compliance
+  with the 'Paris Principles'
+16.b.1-title: Proportion of population reporting having personally felt discriminated
+  against or harassed in the previous 12 months on the basis of a ground of discrimination
+  prohibited under international human rights law
+17.1.1-title: Total government revenue as a proportion of GDP, by source
+17.1.2-title: Proportion of domestic budget funded by domestic taxes
+17.10.1-title: Worldwide weighted tariff-average
+17.11.1-title: Developing countries’ and least developed countries’ share of global
+  exports
+17.12.1-title: Average tariffs faced by developing countries, least developed countries
+  and small island developing States
+17.13.1-title: Macroeconomic Dashboard
+17.14.1-title: Number of countries with mechanisms in place to enhance policy coherence
+  of sustainable development
+17.15.1-title: Extent of use of country-owned results frameworks and planning tools
+  by providers of development cooperation
+17.16.1-title: Number of countries reporting progress in multi-stakeholder development
+  effectiveness monitoring frameworks that support the achievement of the sustainable
+  development goals
+17.17.1-title: Amount of United States dollars committed to (a) public-private partnerships
+  and (b) civil society partnerships
+17.18.1-title: Proportion of sustainable development indicators produced at the national
+  level with full disaggregation when relevant to the target, in accordance with the
+  Fundamental Principles of Official Statistics
+17.18.2-title: Number of countries that have national statistical legislation that
+  complies with the Fundamental Principles of Official Statistics
+17.18.3-title: Number of countries with a national statistical plan that is fully
+  funded and under implementation, by source of funding
+17.19.1-title: Dollar value of all resources made available to strengthen statistical
+  capacity in developing countries
+17.19.2-title: Proportion of countries that (a) have conducted at least one population
+  and housing census in the last 10 years; and (b) have achieved 100 per cent birth
+  registration and 80 per cent death registration
+17.2.1-title: Net official development assistance, total and to least developed countries,
+  as a proportion of the Organization for Economic Cooperation and Development (OECD)
+  Development Assistance Committee donors’ gross national income (GNI)
+17.3.1-title: Foreign direct investment (FDI), official development assistance and
+  South-South cooperation as a proportion of total domestic budget
+17.3.2-title: Volume of remittances (in United States dollars) as a proportion of
+  total GDP
+17.4.1-title: Debt service as a proportion of exports of goods and services
+17.5.1-title: Number of countries that adopt and implement investment promotion regimes
+  for least developed countries
+17.6.1-title: Number of science and/or technology cooperation agreements and programmes
+  between countries, by type of cooperation
+17.6.2-title: Fixed Internet broadband subscriptions per 100 inhabitants, by speed
+17.7.1-title: Total amount of approved funding for developing countries to promote
+  the development, transfer, dissemination and diffusion of environmentally sound
+  technologies
+17.8.1-title: Proportion of individuals using the Internet
+17.9.1-title: Dollar value of financial and technical assistance (including through
+  North-South, South‐South and triangular cooperation) committed to developing countries
+2.1.1-title: Prevalence of undernourishment
+2.1.2-title: Prevalence of moderate or severe food insecurity in the population, based
+  on the Food Insecurity Experience Scale (FIES)
+2.2.1-title: Prevalence of stunting (height for age <-2 standard deviation from the
+  median of the World Health Organization (WHO) Child Growth Standards) among children
+  under 5 years of age
+2.2.2-title: Prevalence of malnutrition (weight for height >+2 or <-2 standard deviation
+  from the median of the WHO Child Growth Standards) among children under 5 years
+  of age, by type (wasting and overweight)
+2.3.1-title: Volume of production per labour unit by classes of farming/pastoral/forestry
+  enterprise size
+2.3.2-title: Average income of small-scale food producers, by sex and indigenous status
+2.4.1-title: Proportion of agricultural area under productive and sustainable agriculture
+2.5.1-title: Number of plant and animal genetic resources for food and agriculture
+  secured in either medium- or long-term conservation facilities
+2.5.2-title: Proportion of local breeds classified as being at risk, not at risk or
+  at unknown level of risk of extinction
+2.a.1-title: The 'agriculture orientation index' for government expenditures
+2.a.2-title: Total official flows (official development assistance plus other official
+  flows) to the agriculture sector
+2.b.1-title: Agricultural export subsidies
+2.b.2-title: Agricultural export subsidies
+2.c.1-title: Indicator of food price anomalies
+3.1.1-title: Maternal mortality ratio
+3.1.2-title: Proportion of births attended by skilled health personnel
+3.2.1-title: Under-5 mortality rate
+3.2.2-title: Neonatal mortality rate
+3.3.1-title: Number of new HIV infections per 1,000 uninfected population, by sex,
+  age and key populations
+3.3.2-title: Tuberculosis incidence per 100,000 population
+3.3.3-title: Malaria incidence per 1,000 population
+3.3.4-title: Hepatitis B incidence per 100,000 population
+3.3.5-title: Number of people requiring interventions against neglected tropical diseases
+3.4.1-title: Mortality rate attributed to cardiovascular disease, cancer, diabetes
+  or chronic respiratory disease
+3.4.2-title: Suicide mortality rate
+3.5.1-title: Coverage of treatment interventions (pharmacological, psychosocial and
+  rehabilitation and aftercare services) for substance use disorders
+3.5.2-title: Harmful use of alcohol, defined according to the national context as
+  alcohol per capita consumption (aged 15 years and older) within a calendar year
+  in litres of pure alcohol
+3.6.1-title: Death rate due to road traffic injuries
+3.7.1-title: Proportion of women of reproductive age (aged 15–49 years) who have their
+  need for family planning satisfied with modern methods
+3.7.2-title: Adolescent birth rate (aged 10–14 years; aged 15–19 years) per 1,000
+  women in that age group
+3.8.1-title: Coverage of essential health services (defined as the average coverage
+  of essential services based on tracer interventions that include reproductive, maternal,
+  newborn and child health, infectious diseases, non-communicable diseases and service
+  capacity and access, among the general and the most disadvantaged population)
+3.8.2-title: Proportion of population with large household expenditures on health
+  as a share of total household expenditure or income
+3.9.1-title: Mortality rate attributed to household and ambient air pollution
+3.9.2-title: Mortality rate attributed to unsafe water, unsafe sanitation and lack
+  of hygiene (exposure to unsafe Water, Sanitation and Hygiene for All (WASH) services)
+3.9.3-title: Mortality rate attributed to unintentional poisoning
+3.a.1-title: Age-standardized prevalence of current tobacco use among persons aged
+  15 years and older
+3.b.1-title: Proportion of the target population covered by all vaccines included
+  in their national programme
+3.b.2-title: Total net official development assistance to medical research and basic
+  health sectors
+3.b.3-title: Proportion of health facilities that have a core set of relevant essential
+  medicines available and affordable on a sustainable basis
+3.c.1-title: Health worker density and distribution
+3.d.1-title: International Health Regulations (IHR) capacity and health emergency
+  preparedness
+4.1.1-title: Proportion of children and young people (a) in grades 2/3; (b) at the
+  end of primary; and (c) at the end of lower secondary achieving at least a minimum
+  proficiency level in (i) reading and (ii) mathematics, by sex
+4.2.1-title: Proportion of children under 5 years of age who are developmentally on
+  track in health, learning and psychosocial well-being, by sex
+4.2.2-title: Participation rate in organized learning (one year before the official
+  primary entry age), by sex
+4.3.1-title: Participation rate of youth and adults in formal and non-formal education
+  and training in the previous 12 months, by sex
+4.4.1-title: Proportion of youth and adults with information and communications technology
+  (ICT) skills, by type of skill
+4.5.1-title: Parity indices (female/male, rural/urban, bottom/top wealth quintile
+  and others such as disability status, indigenous peoples and conflict-affected,
+  as data become available) for all education indicators on this list that can be
+  disaggregated
+4.6.1-title: Proportion of population in a given age group achieving at least a fixed
+  level of proficiency in functional (a) literacy and (b) numeracy skills, by sex
+4.7.1-title: Extent to which (i) global citizenship education and (ii) education for
+  sustainable development, including gender equality and human rights, are mainstreamed
+  at all levels in (a) national education policies; (b) curricula; (c) teacher education;
+  and (d) student assessment
+4.a.1-title: Proportion of schools with access to (a) electricity; (b) the Internet
+  for pedagogical purposes; (c) computers for pedagogical purposes; (d) adapted infrastructure
+  and materials for students with disabilities; (e) basic drinking water; (f) single-sex
+  basic sanitation facilities; and (g) basic handwashing facilities (as per the WASH
+  indicator definitions)
+4.b.1-title: Volume of official development assistance flows for scholarships by sector
+  and type of study
+4.c.1-title: 'Proportion of teachers in: (a) pre-primary; (b) primary; (c) lower secondary;
+  and (d) upper secondary education who have received at least the minimum organized
+  teacher training (e.g. pedagogical training) pre-service or in-service required
+  for teaching at the relevant level in a given country'
+5.1.1-title: Whether or not legal frameworks are in place to promote, enforce and
+  monitor equality and non‐discrimination on the basis of sex
+5.2.1-title: Proportion of ever-partnered women and girls aged 15 years and older
+  subjected to physical, sexual or psychological violence by a current or former intimate
+  partner in the previous 12 months, by form of violence and by age
+5.2.2-title: Proportion of women and girls aged 15 years and older subjected to sexual
+  violence by persons other than an intimate partner in the previous 12 months, by
+  age and place of occurrence
+5.3.1-title: Proportion of women aged 20–24 years who were married or in a union before
+  age 15 and before age 18
+5.3.2-title: Proportion of girls and women aged 15–49 years who have undergone female
+  genital mutilation/cutting, by age
+5.4.1-title: Proportion of time spent on unpaid domestic and care work, by sex, age
+  and location
+5.5.1-title: Proportion of seats held by women in (a) national parliaments and (b)
+  local governments
+5.5.2-title: Proportion of women in managerial positions
+5.6.1-title: Proportion of women aged 15–49 years who make their own informed decisions
+  regarding sexual relations, contraceptive use and reproductive health care
+5.6.2-title: Number of countries with laws and regulations that guarantee full and
+  equal access to women and men aged 15 years and older to sexual and reproductive
+  health care, information and education
+5.a.1-title: (a) Proportion of total agricultural population with ownership or secure
+  rights over agricultural land, by sex; and (b) share of women among owners or rights-bearers
+  of agricultural land, by type of tenure
+5.a.2-title: Proportion of countries where the legal framework (including customary
+  law) guarantees women’s equal rights to land ownership and/or control
+5.b.1-title: Proportion of individuals who own a mobile telephone, by sex
+5.c.1-title: Proportion of countries with systems to track and make public allocations
+  for gender equality and women’s empowerment
+6.1.1-title: Proportion of population using safely managed drinking water services
+6.2.1-title: Proportion of population using (a) safely managed sanitation services
+  and (b) a hand-washing facility with soap and water
+6.3.1-title: Proportion of wastewater safely treated
+6.3.2-title: Proportion of bodies of water with good ambient water quality
+6.4.1-title: Change in water-use efficiency over time
+6.4.2-title: 'Level of water stress: freshwater withdrawal as a proportion of available
+  freshwater resources'
+6.5.1-title: Degree of integrated water resources management implementation (0–100)
+6.5.2-title: Proportion of transboundary basin area with an operational arrangement
+  for water cooperation
+6.6.1-title: Change in the extent of water-related ecosystems over time
+6.a.1-title: Amount of water- and sanitation-related official development assistance
+  that is part of a government-coordinated spending plan
+6.b.1-title: Proportion of local administrative units with established and operational
+  policies and procedures for participation of local communities in water and sanitation
+  management
+7.1.1-title: Proportion of population with access to electricity
+7.1.2-title: Proportion of population with primary reliance on clean fuels and technology
+7.2.1-title: Renewable energy share in the total final energy consumption
+7.3.1-title: Energy intensity measured in terms of primary energy and GDP
+7.a.1-title: International financial flows to developing countries in support of clean
+  energy research and development and renewable energy production, including in hybrid
+  systems
+7.b.1-title: Investments in energy efficiency as a proportion of GDP and the amount
+  of foreign direct investment in financial transfer for infrastructure and technology
+  to sustainable development services
+8.1.1-title: Annual growth rate of real GDP per capita
+8.10.1-title: (a) Number of commercial bank branches per 100,000 adults and (b) number
+  of automated teller machines (ATMs) per 100,000 adults
+8.10.2-title: Proportion of adults (15 years and older) with an account at a bank
+  or other financial institution or with a mobile-money-service provider
+8.2.1-title: Annual growth rate of real GDP per employed person
+8.3.1-title: Proportion of informal employment in non‐agriculture employment, by sex
+8.4.1-title: Material footprint, material footprint per capita, and material footprint
+  per GDP
+8.4.2-title: Domestic material consumption, domestic material consumption per capita,
+  and domestic material consumption per GDP
+8.5.1-title: Average hourly earnings of female and male employees, by occupation,
+  age and persons with disabilities
+8.5.2-title: Unemployment rate, by sex, age and persons with disabilities
+8.6.1-title: Proportion of youth (aged 15–24 years) not in education, employment or
+  training
+8.7.1-title: Proportion and number of children aged 5–17 years engaged in child labour,
+  by sex and age
+8.8.1-title: Frequency rates of fatal and non-fatal occupational injuries, by sex
+  and migrant status
+8.8.2-title: Level of national compliance with labour rights (freedom of association
+  and collective bargaining) based on International Labour Organization (ILO) textual
+  sources and national legislation, by sex and migrant status
+8.9.1-title: Tourism direct GDP as a proportion of total GDP and in growth rate
+8.9.2-title: Proportion of jobs in sustainable tourism industries out of total tourism
+  jobs
+8.a.1-title: Aid for Trade commitments and disbursements
+8.b.1-title: Existence of a developed and operationalized national strategy for youth
+  employment, as a distinct strategy or as part of a national employment strategy
+9.1.1-title: Proportion of the rural population who live within 2 km of an all-season
+  road
+9.1.2-title: Passenger and freight volumes, by mode of transport
+9.2.1-title: Manufacturing value added as a proportion of GDP and per capita
+9.2.2-title: Manufacturing employment as a proportion of total employment
+9.3.1-title: Proportion of small-scale industries in total industry value added
+9.3.2-title: Proportion of small-scale industries with a loan or line of credit
+9.4.1-title: CO<sub>2</sub> emission per unit of value added
+9.5.1-title: Research and development expenditure as a proportion of GDP
+9.5.2-title: Researchers (in full-time equivalent) per million inhabitants
+9.a.1-title: Total official international support (official development assistance
+  plus other official flows) to infrastructure
+9.b.1-title: Proportion of medium and high-tech industry value added in total value
+  added
+9.c.1-title: Proportion of population covered by a mobile network, by technology

--- a/translations/en/global_targets.yml
+++ b/translations/en/global_targets.yml
@@ -1,672 +1,498 @@
-'1.1':
-  title: By 2030, eradicate extreme poverty for all people everywhere, currently measured
-    as people living on less than $1.25 a day
-'1.2':
-  title: By 2030, reduce at least by half the proportion of men, women and children
-    of all ages living in poverty in all its dimensions according to national definitions
-'1.3':
-  title: Implement nationally appropriate social protection systems and measures for
-    all, including floors, and by 2030 achieve substantial coverage of the poor and
-    the vulnerable
-'1.4':
-  title: By 2030, ensure that all men and women, in particular the poor and the vulnerable,
-    have equal rights to economic resources, as well as access to basic services,
-    ownership and control over land and other forms of property, inheritance, natural
-    resources, appropriate new technology and financial services, including microfinance
-'1.5':
-  title: By 2030, build the resilience of the poor and those in vulnerable situations
-    and reduce their exposure and vulnerability to climate-related extreme events
-    and other economic, social and environmental shocks and disasters
-1.a:
-  title: Ensure significant mobilization of resources from a variety of sources, including
-    through enhanced development cooperation, in order to provide adequate and predictable
-    means for developing countries, in particular least developed countries, to implement
-    programmes and policies to end poverty in all its dimensions
-1.b:
-  title: Create sound policy frameworks at the national, regional and international
-    levels, based on pro-poor and gender-sensitive development strategies, to support
-    accelerated investment in poverty eradication actions
-'10.1':
-  title: By 2030, progressively achieve and sustain income growth of the bottom 40
-    per cent of the population at a rate higher than the national average
-'10.2':
-  title: By 2030, empower and promote the social, economic and political inclusion
-    of all, irrespective of age, sex, disability, race, ethnicity, origin, religion
-    or economic or other status
-'10.3':
-  title: Ensure equal opportunity and reduce inequalities of outcome, including by
-    eliminating discriminatory laws, policies and practices and promoting appropriate
-    legislation, policies and action in this regard
-'10.4':
-  title: Adopt policies, especially fiscal, wage and social protection policies, and
-    progressively achieve greater equality
-'10.5':
-  title: Improve the regulation and monitoring of global financial markets and institutions
-    and strengthen the implementation of such regulations
-'10.6':
-  title: Ensure enhanced representation and voice for developing countries in decision-making
-    in global international economic and financial institutions in order to deliver
-    more effective, credible, accountable and legitimate institutions
-'10.7':
-  title: Facilitate orderly, safe, regular and responsible migration and mobility
-    of people, including through the implementation of planned and well-managed migration
-    policies
-10.a:
-  title: Implement the principle of special and differential treatment for developing
-    countries, in particular least developed countries, in accordance with World Trade
-    Organization agreements
-10.b:
-  title: Encourage official development assistance and financial flows, including
-    foreign direct investment, to States where the need is greatest, in particular
-    least developed countries, African countries, small island developing States and
-    landlocked developing countries, in accordance with their national plans and programmes
-10.c:
-  title: By 2030, reduce to less than 3 per cent the transaction costs of migrant
-    remittances and eliminate remittance corridors with costs higher than 5 per cent
-'11.1':
-  title: By 2030, ensure access for all to adequate, safe and affordable housing and
-    basic services and upgrade slums
-'11.2':
-  title: By 2030, provide access to safe, affordable, accessible and sustainable transport
-    systems for all, improving road safety, notably by expanding public transport,
-    with special attention to the needs of those in vulnerable situations, women,
-    children, persons with disabilities and older persons
-'11.3':
-  title: By 2030, enhance inclusive and sustainable urbanization and capacity for
-    participatory, integrated and sustainable human settlement planning and management
-    in all countries
-'11.4':
-  title: Strengthen efforts to protect and safeguard the world’s cultural and natural
-    heritage
-'11.5':
-  title: By 2030, significantly reduce the number of deaths and the number of people
-    affected and substantially decrease the direct economic losses relative to global
-    gross domestic product caused by disasters, including water-related disasters,
-    with a focus on protecting the poor and people in vulnerable situations
-'11.6':
-  title: By 2030, reduce the adverse per capita environmental impact of cities, including
-    by paying special attention to air quality and municipal and other waste management
-'11.7':
-  title: By 2030, provide universal access to safe, inclusive and accessible, green
-    and public spaces, in particular for women and children, older persons and persons
-    with disabilities
-11.a:
-  title: Support positive economic, social and environmental links between urban,
-    peri-urban and rural areas by strengthening national and regional development
-    planning
-11.b:
-  title: By 2020, substantially increase the number of cities and human settlements
-    adopting and implementing integrated policies and plans towards inclusion, resource
-    efficiency, mitigation and adaptation to climate change, resilience to disasters,
-    and develop and implement, in line with the Sendai Framework for Disaster Risk
-    Reduction 2015–2030, holistic disaster risk management at all levels
-11.c:
-  title: Support least developed countries, including through financial and technical
-    assistance, in building sustainable and resilient buildings utilizing local materials
-'12.1':
-  title: Implement the 10‐Year Framework of Programmes on Sustainable Consumption
-    and Production Patterns, all countries taking action, with developed countries
-    taking the lead, taking into account the development and capabilities of developing
-    countries
-'12.2':
-  title: By 2030, achieve the sustainable management and efficient use of natural
-    resources
-'12.3':
-  title: By 2030, halve per capita global food waste at the retail and consumer levels
-    and reduce food losses along production and supply chains, including post-harvest
-    losses
-'12.4':
-  title: By 2020, achieve the environmentally sound management of chemicals and all
-    wastes throughout their life cycle, in accordance with agreed international frameworks,
-    and significantly reduce their release to air, water and soil in order to minimize
-    their adverse impacts on human health and the environment
-'12.5':
-  title: By 2030, substantially reduce waste generation through prevention, reduction,
-    recycling and reuse
-'12.6':
-  title: Encourage companies, especially large and transnational companies, to adopt
-    sustainable practices and to integrate sustainability information into their reporting
-    cycle
-'12.7':
-  title: Promote public procurement practices that are sustainable, in accordance
-    with national policies and priorities
-'12.8':
-  title: By 2030, ensure that people everywhere have the relevant information and
-    awareness for sustainable development and lifestyles in harmony with nature
-12.a:
-  title: Support developing countries to strengthen their scientific and technological
-    capacity to move towards more sustainable patterns of consumption and production
-12.b:
-  title: Develop and implement tools to monitor sustainable development impacts for
-    sustainable tourism that creates jobs and promotes local culture and products
-12.c:
-  title: Rationalize inefficient fossil-fuel subsidies that encourage wasteful consumption
-    by removing market distortions, in accordance with national circumstances, including
-    by restructuring taxation and phasing out those harmful subsidies, where they
-    exist, to reflect their environmental impacts, taking fully into account the specific
-    needs and conditions of developing countries and minimizing the possible adverse
-    impacts on their development in a manner that protects the poor and the affected
-    communities
-'13.1':
-  title: Strengthen resilience and adaptive capacity to climate-related hazards and
-    natural disasters in all countries
-'13.2':
-  title: Integrate climate change measures into national policies, strategies and
-    planning
-'13.3':
-  title: Improve education, awareness-raising and human and institutional capacity
-    on climate change mitigation, adaptation, impact reduction and early warning
-13.a:
-  title: Implement the commitment undertaken by developed-country parties to the United
-    Nations Framework Convention on Climate Change to a goal of mobilizing jointly
-    $100 billion annually by 2020 from all sources to address the needs of developing
-    countries in the context of meaningful mitigation actions and transparency on
-    implementation and fully operationalize the Green Climate Fund through its capitalization
-    as soon as possible
-13.b:
-  title: Promote mechanisms for raising capacity for effective climate change-related
-    planning and management in least developed countries and small island developing
-    States, including focusing on women, youth and local and marginalized communities
-'14.1':
-  title: By 2025, prevent and significantly reduce marine pollution of all kinds,
-    in particular from land-based activities, including marine debris and nutrient
-    pollution
-'14.2':
-  title: By 2020, sustainably manage and protect marine and coastal ecosystems to
-    avoid significant adverse impacts, including by strengthening their resilience,
-    and take action for their restoration in order to achieve healthy and productive
-    oceans
-'14.3':
-  title: Minimize and address the impacts of ocean acidification, including through
-    enhanced scientific cooperation at all levels
-'14.4':
-  title: By 2020, effectively regulate harvesting and end overfishing, illegal, unreported
-    and unregulated fishing and destructive fishing practices and implement science-based
-    management plans, in order to restore fish stocks in the shortest time feasible,
-    at least to levels that can produce maximum sustainable yield as determined by
-    their biological characteristics
-'14.5':
-  title: By 2020, conserve at least 10 per cent of coastal and marine areas, consistent
-    with national and international law and based on the best available scientific
-    information
-'14.6':
-  title: By 2020, prohibit certain forms of fisheries subsidies which contribute to
-    overcapacity and overfishing, eliminate subsidies that contribute to illegal,
-    unreported and unregulated fishing and refrain from introducing new such subsidies,
-    recognizing that appropriate and effective special and differential treatment
-    for developing and least developed countries should be an integral part of the
-    World Trade Organization fisheries subsidies negotiation
-'14.7':
-  title: By 2030, increase the economic benefits to small island developing States
-    and least developed countries from the sustainable use of marine resources, including
-    through sustainable management of fisheries, aquaculture and tourism
-14.a:
-  title: Increase scientific knowledge, develop research capacity and transfer marine
-    technology, taking into account the Intergovernmental Oceanographic Commission
-    Criteria and Guidelines on the Transfer of Marine Technology, in order to improve
-    ocean health and to enhance the contribution of marine biodiversity to the development
-    of developing countries, in particular small island developing States and least
-    developed countries
-14.b:
-  title: Provide access for small-scale artisanal fishers to marine resources and
-    markets
-14.c:
-  title: Enhance the conservation and sustainable use of oceans and their resources
-    by implementing international law as reflected in the United Nations Convention
-    on the Law of the Sea, which provides the legal framework for the conservation
-    and sustainable use of oceans and their resources, as recalled in paragraph 158
-    of “The future we want”
-'15.1':
-  title: By 2020, ensure the conservation, restoration and sustainable use of terrestrial
-    and inland freshwater ecosystems and their services, in particular forests, wetlands,
-    mountains and drylands, in line with obligations under international agreements
-'15.2':
-  title: By 2020, promote the implementation of sustainable management of all types
-    of forests, halt deforestation, restore degraded forests and substantially increase
-    afforestation and reforestation globally
-'15.3':
-  title: By 2030, combat desertification, restore degraded land and soil, including
-    land affected by desertification, drought and floods, and strive to achieve a
-    land degradation-neutral world
-'15.4':
-  title: By 2030, ensure the conservation of mountain ecosystems, including their
-    biodiversity, in order to enhance their capacity to provide benefits that are
-    essential for sustainable development
-'15.5':
-  title: Take urgent and significant action to reduce the degradation of natural habitats,
-    halt the loss of biodiversity and, by 2020, protect and prevent the extinction
-    of threatened species
-'15.6':
-  title: Promote fair and equitable sharing of the benefits arising from the utilization
-    of genetic resources and promote appropriate access to such resources, as internationally
-    agreed
-'15.7':
-  title: Take urgent action to end poaching and trafficking of protected species of
-    flora and fauna and address both demand and supply of illegal wildlife products
-'15.8':
-  title: By 2020, introduce measures to prevent the introduction and significantly
-    reduce the impact of invasive alien species on land and water ecosystems and control
-    or eradicate the priority species
-'15.9':
-  title: By 2020, integrate ecosystem and biodiversity values into national and local
-    planning, development processes, poverty reduction strategies and accounts
-15.a:
-  title: Mobilize and significantly increase financial resources from all sources
-    to conserve and sustainably use biodiversity and ecosystems
-15.b:
-  title: Mobilize significant resources from all sources and at all levels to finance
-    sustainable forest management and provide adequate incentives to developing countries
-    to advance such management, including for conservation and reforestation
-15.c:
-  title: Enhance global support for efforts to combat poaching and trafficking of
-    protected species, including by increasing the capacity of local communities to
-    pursue sustainable livelihood opportunities
-'16.1':
-  title: Significantly reduce all forms of violence and related death rates everywhere
-'16.10':
-  title: Ensure public access to information and protect fundamental freedoms, in
-    accordance with national legislation and international agreements
-'16.2':
-  title: End abuse, exploitation, trafficking and all forms of violence against and
-    torture of children
-'16.3':
-  title: Promote the rule of law at the national and international levels and ensure
-    equal access to justice for all
-'16.4':
-  title: By 2030, significantly reduce illicit financial and arms flows, strengthen
-    the recovery and return of stolen assets and combat all forms of organized crime
-'16.5':
-  title: Substantially reduce corruption and bribery in all their forms
-'16.6':
-  title: Develop effective, accountable and transparent institutions at all levels
-'16.7':
-  title: Ensure responsive, inclusive, participatory and representative decision-making
-    at all levels
-'16.8':
-  title: Broaden and strengthen the participation of developing countries in the institutions
-    of global governance
-'16.9':
-  title: By 2030, provide legal identity for all, including birth registration
-16.a:
-  title: Strengthen relevant national institutions, including through international
-    cooperation, for building capacity at all levels, in particular in developing
-    countries, to prevent violence and combat terrorism and crime
-16.b:
-  title: Promote and enforce non-discriminatory laws and policies for sustainable
-    development
-'17.1':
-  title: Strengthen domestic resource mobilization, including through international
-    support to developing countries, to improve domestic capacity for tax and other
-    revenue collection
-'17.10':
-  title: Promote a universal, rules-based, open, non‐discriminatory and equitable
-    multilateral trading system under the World Trade Organization, including through
-    the conclusion of negotiations under its Doha Development Agenda
-'17.11':
-  title: Significantly increase the exports of developing countries, in particular
-    with a view to doubling the least developed countries’ share of global exports
-    by 2020
-'17.12':
-  title: Realize timely implementation of duty-free and quota-free market access on
-    a lasting basis for all least developed countries, consistent with World Trade
-    Organization decisions, including by ensuring that preferential rules of origin
-    applicable to imports from least developed countries are transparent and simple,
-    and contribute to facilitating market access
-'17.13':
-  title: Enhance global macroeconomic stability, including through policy coordination
-    and policy coherence
-'17.14':
-  title: Enhance policy coherence for sustainable development
-'17.15':
-  title: Respect each country’s policy space and leadership to establish and implement
-    policies for poverty eradication and sustainable development
-'17.16':
-  title: Enhance the Global Partnership for Sustainable Development, complemented
-    by multi-stakeholder partnerships that mobilize and share knowledge, expertise,
-    technology and financial resources, to support the achievement of the Sustainable
-    Development Goals in all countries, in particular developing countries
-'17.17':
-  title: Encourage and promote effective public, public-private and civil society
-    partnerships, building on the experience and resourcing strategies of partnerships
-'17.18':
-  title: By 2020, enhance capacity-building support to developing countries, including
-    for least developed countries and small island developing States, to increase
-    significantly the availability of high-quality, timely and reliable data disaggregated
-    by income, gender, age, race, ethnicity, migratory status, disability, geographic
-    location and other characteristics relevant in national contexts
-'17.19':
-  title: By 2030, build on existing initiatives to develop measurements of progress
-    on sustainable development that complement gross domestic product, and support
-    statistical capacity-building in developing countries
-'17.2':
-  title: Developed countries to implement fully their official development assistance
-    commitments, including the commitment by many developed countries to achieve the
-    target of 0.7 per cent of gross national income for official development assistance
-    (ODA/GNI) to developing countries and 0.15 to 0.20 per cent of ODA/GNI to least
-    developed countries; ODA providers are encouraged to consider setting a target
-    to provide at least 0.20 per cent of ODA/GNI to least developed countries
-'17.3':
-  title: Mobilize additional financial resources for developing countries from multiple
-    sources
-'17.4':
-  title: Assist developing countries in attaining long-term debt sustainability through
-    coordinated policies aimed at fostering debt financing, debt relief and debt restructuring,
-    as appropriate, and address the external debt of highly indebted poor countries
-    to reduce debt distress
-'17.5':
-  title: Adopt and implement investment promotion regimes for least developed countries
-'17.6':
-  title: Enhance North-South, South-South and triangular regional and international
-    cooperation on and access to science, technology and innovation and enhance knowledge-sharing
-    on mutually agreed terms, including through improved coordination among existing
-    mechanisms, in particular at the United Nations level, and through a global technology
-    facilitation mechanism
-'17.7':
-  title: Promote the development, transfer, dissemination and diffusion of environmentally
-    sound technologies to developing countries on favourable terms, including on concessional
-    and preferential terms, as mutually agreed
-'17.8':
-  title: Fully operationalize the technology bank and science, technology and innovation
-    capacity-building mechanism for least developed countries by 2017 and enhance
-    the use of enabling technology, in particular information and communications technology
-'17.9':
-  title: Enhance international support for implementing effective and targeted capacity-building
-    in developing countries to support national plans to implement all the Sustainable
-    Development Goals, including through North-South, South-South and triangular cooperation
-'2.1':
-  title: By 2030, end hunger and ensure access by all people, in particular the poor
-    and people in vulnerable situations, including infants, to safe, nutritious and
-    sufficient food all year round
-'2.2':
-  title: By 2030, end all forms of malnutrition, including achieving, by 2025, the
-    internationally agreed targets on stunting and wasting in children under 5 years
-    of age, and address the nutritional needs of adolescent girls, pregnant and lactating
-    women and older persons
-'2.3':
-  title: By 2030, double the agricultural productivity and incomes of small-scale
-    food producers, in particular women, indigenous peoples, family farmers, pastoralists
-    and fishers, including through secure and equal access to land, other productive
-    resources and inputs, knowledge, financial services, markets and opportunities
-    for value addition and non-farm employment
-'2.4':
-  title: By 2030, ensure sustainable food production systems and implement resilient
-    agricultural practices that increase productivity and production, that help maintain
-    ecosystems, that strengthen capacity for adaptation to climate change, extreme
-    weather, drought, flooding and other disasters and that progressively improve
-    land and soil quality
-'2.5':
-  title: By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed
-    and domesticated animals and their related wild species, including through soundly
-    managed and diversified seed and plant banks at the national, regional and international
-    levels, and promote access to and fair and equitable sharing of benefits arising
-    from the utilization of genetic resources and associated traditional knowledge,
-    as internationally agreed
-2.a:
-  title: Increase investment, including through enhanced international cooperation,
-    in rural infrastructure, agricultural research and extension services, technology
-    development and plant and livestock gene banks in order to enhance agricultural
-    productive capacity in developing countries, in particular least developed countries
-2.b:
-  title: Correct and prevent trade restrictions and distortions in world agricultural
-    markets, including through the parallel elimination of all forms of agricultural
-    export subsidies and all export measures with equivalent effect, in accordance
-    with the mandate of the Doha Development Round
-2.c:
-  title: Adopt measures to ensure the proper functioning of food commodity markets
-    and their derivatives and facilitate timely access to market information, including
-    on food reserves, in order to help limit extreme food price volatility
-'3.1':
-  title: By 2030, reduce the global maternal mortality ratio to less than 70 per 100,000
-    live births
-'3.2':
-  title: By 2030, end preventable deaths of newborns and children under 5 years of
-    age, with all countries aiming to reduce neonatal mortality to at least as low
-    as 12 per 1,000 live births and under‐5 mortality to at least as low as 25 per
-    1,000 live births
-'3.3':
-  title: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-    diseases and combat hepatitis, water-borne diseases and other communicable diseases
-'3.4':
-  title: By 2030, reduce by one third premature mortality from non-communicable diseases
-    through prevention and treatment and promote mental health and well-being
-'3.5':
-  title: Strengthen the prevention and treatment of substance abuse, including narcotic
-    drug abuse and harmful use of alcohol
-'3.6':
-  title: By 2020, halve the number of global deaths and injuries from road traffic
-    accidents
-'3.7':
-  title: By 2030, ensure universal access to sexual and reproductive health-care services,
-    including for family planning, information and education, and the integration
-    of reproductive health into national strategies and programmes
-'3.8':
-  title: Achieve universal health coverage, including financial risk protection, access
-    to quality essential health-care services and access to safe, effective, quality
-    and affordable essential medicines and vaccines for all
-'3.9':
-  title: By 2030, substantially reduce the number of deaths and illnesses from hazardous
-    chemicals and air, water and soil pollution and contamination
-3.a:
-  title: Strengthen the implementation of the World Health Organization Framework
-    Convention on Tobacco Control in all countries, as appropriate
-3.b:
-  title: Support the research and development of vaccines and medicines for the communicable
-    and non‐communicable diseases that primarily affect developing countries, provide
-    access to affordable essential medicines and vaccines, in accordance with the
-    Doha Declaration on the TRIPS Agreement and Public Health, which affirms the right
-    of developing countries to use to the full the provisions in the Agreement on
-    Trade-Related Aspects of Intellectual Property Rights regarding flexibilities
-    to protect public health, and, in particular, provide access to medicines for
-    all
-3.c:
-  title: Substantially increase health financing and the recruitment, development,
-    training and retention of the health workforce in developing countries, especially
-    in least developed countries and small island developing States
-3.d:
-  title: Strengthen the capacity of all countries, in particular developing countries,
-    for early warning, risk reduction and management of national and global health
-    risks
-'4.1':
-  title: By 2030, ensure that all girls and boys complete free, equitable and quality
-    primary and secondary education leading to relevant and effective learning outcomes
-'4.2':
-  title: By 2030, ensure that all girls and boys have access to quality early childhood
-    development, care and pre‐primary education so that they are ready for primary
-    education
-'4.3':
-  title: By 2030, ensure equal access for all women and men to affordable and quality
-    technical, vocational and tertiary education, including university
-'4.4':
-  title: By 2030, substantially increase the number of youth and adults who have relevant
-    skills, including technical and vocational skills, for employment, decent jobs
-    and entrepreneurship
-'4.5':
-  title: By 2030, eliminate gender disparities in education and ensure equal access
-    to all levels of education and vocational training for the vulnerable, including
-    persons with disabilities, indigenous peoples and children in vulnerable situations
-'4.6':
-  title: By 2030, ensure that all youth and a substantial proportion of adults, both
-    men and women, achieve literacy and numeracy
-'4.7':
-  title: By 2030, ensure that all learners acquire the knowledge and skills needed
-    to promote sustainable development, including, among others, through education
-    for sustainable development and sustainable lifestyles, human rights, gender equality,
-    promotion of a culture of peace and non-violence, global citizenship and appreciation
-    of cultural diversity and of culture’s contribution to sustainable development
-4.a:
-  title: Build and upgrade education facilities that are child, disability and gender
-    sensitive and provide safe, non-violent, inclusive and effective learning environments
-    for all
-4.b:
-  title: By 2020, substantially expand globally the number of scholarships available
-    to developing countries, in particular least developed countries, small island
-    developing States and African countries, for enrolment in higher education, including
-    vocational training and information and communications technology, technical,
-    engineering and scientific programmes, in developed countries and other developing
-    countries
-4.c:
-  title: By 2030, substantially increase the supply of qualified teachers, including
-    through international cooperation for teacher training in developing countries,
-    especially least developed countries and small island developing States
-'5.1':
-  title: End all forms of discrimination against all women and girls everywhere
-'5.2':
-  title: Eliminate all forms of violence against all women and girls in the public
-    and private spheres, including trafficking and sexual and other types of exploitation
-'5.3':
-  title: Eliminate all harmful practices, such as child, early and forced marriage
-    and female genital mutilation
-'5.4':
-  title: Recognize and value unpaid care and domestic work through the provision of
-    public services, infrastructure and social protection policies and the promotion
-    of shared responsibility within the household and the family as nationally appropriate
-'5.5':
-  title: Ensure women’s full and effective participation and equal opportunities for
-    leadership at all levels of decision-making in political, economic and public
-    life
-'5.6':
-  title: Ensure universal access to sexual and reproductive health and reproductive
-    rights as agreed in accordance with the Programme of Action of the International
-    Conference on Population and Development and the Beijing Platform for Action and
-    the outcome documents of their review conferences
-5.a:
-  title: Undertake reforms to give women equal rights to economic resources, as well
-    as access to ownership and control over land and other forms of property, financial
-    services, inheritance and natural resources, in accordance with national laws
-5.b:
-  title: Enhance the use of enabling technology, in particular information and communications
-    technology, to promote the empowerment of women
-5.c:
-  title: Adopt and strengthen sound policies and enforceable legislation for the promotion
-    of gender equality and the empowerment of all women and girls at all levels
-'6.1':
-  title: By 2030, achieve universal and equitable access to safe and affordable drinking
-    water for all
-'6.2':
-  title: By 2030, achieve access to adequate and equitable sanitation and hygiene
-    for all and end open defecation, paying special attention to the needs of women
-    and girls and those in vulnerable situations
-'6.3':
-  title: By 2030, improve water quality by reducing pollution, eliminating dumping
-    and minimizing release of hazardous chemicals and materials, halving the proportion
-    of untreated wastewater and substantially increasing recycling and safe reuse
-    globally
-'6.4':
-  title: By 2030, substantially increase water-use efficiency across all sectors and
-    ensure sustainable withdrawals and supply of freshwater to address water scarcity
-    and substantially reduce the number of people suffering from water scarcity
-'6.5':
-  title: By 2030, implement integrated water resources management at all levels, including
-    through transboundary cooperation as appropriate
-'6.6':
-  title: By 2020, protect and restore water-related ecosystems, including mountains,
-    forests, wetlands, rivers, aquifers and lakes
-6.a:
-  title: By 2030, expand international cooperation and capacity-building support to
-    developing countries in water- and sanitation-related activities and programmes,
-    including water harvesting, desalination, water efficiency, wastewater treatment,
-    recycling and reuse technologies
-6.b:
-  title: Support and strengthen the participation of local communities in improving
-    water and sanitation management
-'7.1':
-  title: By 2030, ensure universal access to affordable, reliable and modern energy
-    services
-'7.2':
-  title: By 2030, increase substantially the share of renewable energy in the global
-    energy mix
-'7.3':
-  title: By 2030, double the global rate of improvement in energy efficiency
-7.a:
-  title: By 2030, enhance international cooperation to facilitate access to clean
-    energy research and technology, including renewable energy, energy efficiency
-    and advanced and cleaner fossil-fuel technology, and promote investment in energy
-    infrastructure and clean energy technology
-7.b:
-  title: By 2030, expand infrastructure and upgrade technology for supplying modern
-    and sustainable energy services for all in developing countries, in particular
-    least developed countries, small island developing States and landlocked developing
-    countries, in accordance with their respective programmes of support
-'8.1':
-  title: Sustain per capita economic growth in accordance with national circumstances
-    and, in particular, at least 7 per cent gross domestic product growth per annum
-    in the least developed countries
-'8.10':
-  title: Strengthen the capacity of domestic financial institutions to encourage and
-    expand access to banking, insurance and financial services for all
-'8.2':
-  title: Achieve higher levels of economic productivity through diversification, technological
-    upgrading and innovation, including through a focus on high-value added and labour-intensive
-    sectors
-'8.3':
-  title: Promote development-oriented policies that support productive activities,
-    decent job creation, entrepreneurship, creativity and innovation, and encourage
-    the formalization and growth of micro-, small- and medium-sized enterprises, including
-    through access to financial services
-'8.4':
-  title: Improve progressively, through 2030, global resource efficiency in consumption
-    and production and endeavour to decouple economic growth from environmental degradation,
-    in accordance with the 10‐Year Framework of Programmes on Sustainable Consumption
-    and Production, with developed countries taking the lead
-'8.5':
-  title: By 2030, achieve full and productive employment and decent work for all women
-    and men, including for young people and persons with disabilities, and equal pay
-    for work of equal value
-'8.6':
-  title: By 2020, substantially reduce the proportion of youth not in employment,
-    education or training
-'8.7':
-  title: Take immediate and effective measures to eradicate forced labour, end modern
-    slavery and human trafficking and secure the prohibition and elimination of the
-    worst forms of child labour, including recruitment and use of child soldiers,
-    and by 2025 end child labour in all its forms
-'8.8':
-  title: Protect labour rights and promote safe and secure working environments for
-    all workers, including migrant workers, in particular women migrants, and those
-    in precarious employment
-'8.9':
-  title: By 2030, devise and implement policies to promote sustainable tourism that
-    creates jobs and promotes local culture and products
-8.a:
-  title: Increase Aid for Trade support for developing countries, in particular least
-    developed countries, including through the Enhanced Integrated Framework for Trade-related
-    Technical Assistance to Least Developed Countries
-8.b:
-  title: By 2020, develop and operationalize a global strategy for youth employment
-    and implement the Global Jobs Pact of the International Labour Organization
-'9.1':
-  title: Develop quality, reliable, sustainable and resilient infrastructure, including
-    regional and transborder infrastructure, to support economic development and human
-    well-being, with a focus on affordable and equitable access for all
-'9.2':
-  title: Promote inclusive and sustainable industrialization and, by 2030, significantly
-    raise industry’s share of employment and gross domestic product, in line with
-    national circumstances, and double its share in least developed countries
-'9.3':
-  title: Increase the access of small-scale industrial and other enterprises, in particular
-    in developing countries, to financial services, including affordable credit, and
-    their integration into value chains and markets
-'9.4':
-  title: By 2030, upgrade infrastructure and retrofit industries to make them sustainable,
-    with increased resource-use efficiency and greater adoption of clean and environmentally
-    sound technologies and industrial processes, with all countries taking action
-    in accordance with their respective capabilities
-'9.5':
-  title: Enhance scientific research, upgrade the technological capabilities of industrial
-    sectors in all countries, in particular developing countries, including, by 2030,
-    encouraging innovation and substantially increasing the number of research and
-    development workers per 1 million people and public and private research and development
-    spending
-9.a:
-  title: Facilitate sustainable and resilient infrastructure development in developing
-    countries through enhanced financial, technological and technical support to African
-    countries, least developed countries, landlocked developing countries and small
-    island developing States
-9.b:
-  title: Support domestic technology development, research and innovation in developing
-    countries, including by ensuring a conducive policy environment for, inter alia,
-    industrial diversification and value addition to commodities
-9.c:
-  title: Significantly increase access to information and communications technology
-    and strive to provide universal and affordable access to the Internet in least
-    developed countries by 2020
+1.1-title: By 2030, eradicate extreme poverty for all people everywhere, currently
+  measured as people living on less than $1.25 a day
+1.2-title: By 2030, reduce at least by half the proportion of men, women and children
+  of all ages living in poverty in all its dimensions according to national definitions
+1.3-title: Implement nationally appropriate social protection systems and measures
+  for all, including floors, and by 2030 achieve substantial coverage of the poor
+  and the vulnerable
+1.4-title: By 2030, ensure that all men and women, in particular the poor and the
+  vulnerable, have equal rights to economic resources, as well as access to basic
+  services, ownership and control over land and other forms of property, inheritance,
+  natural resources, appropriate new technology and financial services, including
+  microfinance
+1.5-title: By 2030, build the resilience of the poor and those in vulnerable situations
+  and reduce their exposure and vulnerability to climate-related extreme events and
+  other economic, social and environmental shocks and disasters
+1.a-title: Ensure significant mobilization of resources from a variety of sources,
+  including through enhanced development cooperation, in order to provide adequate
+  and predictable means for developing countries, in particular least developed countries,
+  to implement programmes and policies to end poverty in all its dimensions
+1.b-title: Create sound policy frameworks at the national, regional and international
+  levels, based on pro-poor and gender-sensitive development strategies, to support
+  accelerated investment in poverty eradication actions
+10.1-title: By 2030, progressively achieve and sustain income growth of the bottom
+  40 per cent of the population at a rate higher than the national average
+10.2-title: By 2030, empower and promote the social, economic and political inclusion
+  of all, irrespective of age, sex, disability, race, ethnicity, origin, religion
+  or economic or other status
+10.3-title: Ensure equal opportunity and reduce inequalities of outcome, including
+  by eliminating discriminatory laws, policies and practices and promoting appropriate
+  legislation, policies and action in this regard
+10.4-title: Adopt policies, especially fiscal, wage and social protection policies,
+  and progressively achieve greater equality
+10.5-title: Improve the regulation and monitoring of global financial markets and
+  institutions and strengthen the implementation of such regulations
+10.6-title: Ensure enhanced representation and voice for developing countries in decision-making
+  in global international economic and financial institutions in order to deliver
+  more effective, credible, accountable and legitimate institutions
+10.7-title: Facilitate orderly, safe, regular and responsible migration and mobility
+  of people, including through the implementation of planned and well-managed migration
+  policies
+10.a-title: Implement the principle of special and differential treatment for developing
+  countries, in particular least developed countries, in accordance with World Trade
+  Organization agreements
+10.b-title: Encourage official development assistance and financial flows, including
+  foreign direct investment, to States where the need is greatest, in particular least
+  developed countries, African countries, small island developing States and landlocked
+  developing countries, in accordance with their national plans and programmes
+10.c-title: By 2030, reduce to less than 3 per cent the transaction costs of migrant
+  remittances and eliminate remittance corridors with costs higher than 5 per cent
+11.1-title: By 2030, ensure access for all to adequate, safe and affordable housing
+  and basic services and upgrade slums
+11.2-title: By 2030, provide access to safe, affordable, accessible and sustainable
+  transport systems for all, improving road safety, notably by expanding public transport,
+  with special attention to the needs of those in vulnerable situations, women, children,
+  persons with disabilities and older persons
+11.3-title: By 2030, enhance inclusive and sustainable urbanization and capacity for
+  participatory, integrated and sustainable human settlement planning and management
+  in all countries
+11.4-title: Strengthen efforts to protect and safeguard the world’s cultural and natural
+  heritage
+11.5-title: By 2030, significantly reduce the number of deaths and the number of people
+  affected and substantially decrease the direct economic losses relative to global
+  gross domestic product caused by disasters, including water-related disasters, with
+  a focus on protecting the poor and people in vulnerable situations
+11.6-title: By 2030, reduce the adverse per capita environmental impact of cities,
+  including by paying special attention to air quality and municipal and other waste
+  management
+11.7-title: By 2030, provide universal access to safe, inclusive and accessible, green
+  and public spaces, in particular for women and children, older persons and persons
+  with disabilities
+11.a-title: Support positive economic, social and environmental links between urban,
+  peri-urban and rural areas by strengthening national and regional development planning
+11.b-title: By 2020, substantially increase the number of cities and human settlements
+  adopting and implementing integrated policies and plans towards inclusion, resource
+  efficiency, mitigation and adaptation to climate change, resilience to disasters,
+  and develop and implement, in line with the Sendai Framework for Disaster Risk Reduction
+  2015–2030, holistic disaster risk management at all levels
+11.c-title: Support least developed countries, including through financial and technical
+  assistance, in building sustainable and resilient buildings utilizing local materials
+12.1-title: Implement the 10‐Year Framework of Programmes on Sustainable Consumption
+  and Production Patterns, all countries taking action, with developed countries taking
+  the lead, taking into account the development and capabilities of developing countries
+12.2-title: By 2030, achieve the sustainable management and efficient use of natural
+  resources
+12.3-title: By 2030, halve per capita global food waste at the retail and consumer
+  levels and reduce food losses along production and supply chains, including post-harvest
+  losses
+12.4-title: By 2020, achieve the environmentally sound management of chemicals and
+  all wastes throughout their life cycle, in accordance with agreed international
+  frameworks, and significantly reduce their release to air, water and soil in order
+  to minimize their adverse impacts on human health and the environment
+12.5-title: By 2030, substantially reduce waste generation through prevention, reduction,
+  recycling and reuse
+12.6-title: Encourage companies, especially large and transnational companies, to
+  adopt sustainable practices and to integrate sustainability information into their
+  reporting cycle
+12.7-title: Promote public procurement practices that are sustainable, in accordance
+  with national policies and priorities
+12.8-title: By 2030, ensure that people everywhere have the relevant information and
+  awareness for sustainable development and lifestyles in harmony with nature
+12.a-title: Support developing countries to strengthen their scientific and technological
+  capacity to move towards more sustainable patterns of consumption and production
+12.b-title: Develop and implement tools to monitor sustainable development impacts
+  for sustainable tourism that creates jobs and promotes local culture and products
+12.c-title: Rationalize inefficient fossil-fuel subsidies that encourage wasteful
+  consumption by removing market distortions, in accordance with national circumstances,
+  including by restructuring taxation and phasing out those harmful subsidies, where
+  they exist, to reflect their environmental impacts, taking fully into account the
+  specific needs and conditions of developing countries and minimizing the possible
+  adverse impacts on their development in a manner that protects the poor and the
+  affected communities
+13.1-title: Strengthen resilience and adaptive capacity to climate-related hazards
+  and natural disasters in all countries
+13.2-title: Integrate climate change measures into national policies, strategies and
+  planning
+13.3-title: Improve education, awareness-raising and human and institutional capacity
+  on climate change mitigation, adaptation, impact reduction and early warning
+13.a-title: Implement the commitment undertaken by developed-country parties to the
+  United Nations Framework Convention on Climate Change to a goal of mobilizing jointly
+  $100 billion annually by 2020 from all sources to address the needs of developing
+  countries in the context of meaningful mitigation actions and transparency on implementation
+  and fully operationalize the Green Climate Fund through its capitalization as soon
+  as possible
+13.b-title: Promote mechanisms for raising capacity for effective climate change-related
+  planning and management in least developed countries and small island developing
+  States, including focusing on women, youth and local and marginalized communities
+14.1-title: By 2025, prevent and significantly reduce marine pollution of all kinds,
+  in particular from land-based activities, including marine debris and nutrient pollution
+14.2-title: By 2020, sustainably manage and protect marine and coastal ecosystems
+  to avoid significant adverse impacts, including by strengthening their resilience,
+  and take action for their restoration in order to achieve healthy and productive
+  oceans
+14.3-title: Minimize and address the impacts of ocean acidification, including through
+  enhanced scientific cooperation at all levels
+14.4-title: By 2020, effectively regulate harvesting and end overfishing, illegal,
+  unreported and unregulated fishing and destructive fishing practices and implement
+  science-based management plans, in order to restore fish stocks in the shortest
+  time feasible, at least to levels that can produce maximum sustainable yield as
+  determined by their biological characteristics
+14.5-title: By 2020, conserve at least 10 per cent of coastal and marine areas, consistent
+  with national and international law and based on the best available scientific information
+14.6-title: By 2020, prohibit certain forms of fisheries subsidies which contribute
+  to overcapacity and overfishing, eliminate subsidies that contribute to illegal,
+  unreported and unregulated fishing and refrain from introducing new such subsidies,
+  recognizing that appropriate and effective special and differential treatment for
+  developing and least developed countries should be an integral part of the World
+  Trade Organization fisheries subsidies negotiation
+14.7-title: By 2030, increase the economic benefits to small island developing States
+  and least developed countries from the sustainable use of marine resources, including
+  through sustainable management of fisheries, aquaculture and tourism
+14.a-title: Increase scientific knowledge, develop research capacity and transfer
+  marine technology, taking into account the Intergovernmental Oceanographic Commission
+  Criteria and Guidelines on the Transfer of Marine Technology, in order to improve
+  ocean health and to enhance the contribution of marine biodiversity to the development
+  of developing countries, in particular small island developing States and least
+  developed countries
+14.b-title: Provide access for small-scale artisanal fishers to marine resources and
+  markets
+14.c-title: Enhance the conservation and sustainable use of oceans and their resources
+  by implementing international law as reflected in the United Nations Convention
+  on the Law of the Sea, which provides the legal framework for the conservation and
+  sustainable use of oceans and their resources, as recalled in paragraph 158 of “The
+  future we want”
+15.1-title: By 2020, ensure the conservation, restoration and sustainable use of terrestrial
+  and inland freshwater ecosystems and their services, in particular forests, wetlands,
+  mountains and drylands, in line with obligations under international agreements
+15.2-title: By 2020, promote the implementation of sustainable management of all types
+  of forests, halt deforestation, restore degraded forests and substantially increase
+  afforestation and reforestation globally
+15.3-title: By 2030, combat desertification, restore degraded land and soil, including
+  land affected by desertification, drought and floods, and strive to achieve a land
+  degradation-neutral world
+15.4-title: By 2030, ensure the conservation of mountain ecosystems, including their
+  biodiversity, in order to enhance their capacity to provide benefits that are essential
+  for sustainable development
+15.5-title: Take urgent and significant action to reduce the degradation of natural
+  habitats, halt the loss of biodiversity and, by 2020, protect and prevent the extinction
+  of threatened species
+15.6-title: Promote fair and equitable sharing of the benefits arising from the utilization
+  of genetic resources and promote appropriate access to such resources, as internationally
+  agreed
+15.7-title: Take urgent action to end poaching and trafficking of protected species
+  of flora and fauna and address both demand and supply of illegal wildlife products
+15.8-title: By 2020, introduce measures to prevent the introduction and significantly
+  reduce the impact of invasive alien species on land and water ecosystems and control
+  or eradicate the priority species
+15.9-title: By 2020, integrate ecosystem and biodiversity values into national and
+  local planning, development processes, poverty reduction strategies and accounts
+15.a-title: Mobilize and significantly increase financial resources from all sources
+  to conserve and sustainably use biodiversity and ecosystems
+15.b-title: Mobilize significant resources from all sources and at all levels to finance
+  sustainable forest management and provide adequate incentives to developing countries
+  to advance such management, including for conservation and reforestation
+15.c-title: Enhance global support for efforts to combat poaching and trafficking
+  of protected species, including by increasing the capacity of local communities
+  to pursue sustainable livelihood opportunities
+16.1-title: Significantly reduce all forms of violence and related death rates everywhere
+16.10-title: Ensure public access to information and protect fundamental freedoms,
+  in accordance with national legislation and international agreements
+16.2-title: End abuse, exploitation, trafficking and all forms of violence against
+  and torture of children
+16.3-title: Promote the rule of law at the national and international levels and ensure
+  equal access to justice for all
+16.4-title: By 2030, significantly reduce illicit financial and arms flows, strengthen
+  the recovery and return of stolen assets and combat all forms of organized crime
+16.5-title: Substantially reduce corruption and bribery in all their forms
+16.6-title: Develop effective, accountable and transparent institutions at all levels
+16.7-title: Ensure responsive, inclusive, participatory and representative decision-making
+  at all levels
+16.8-title: Broaden and strengthen the participation of developing countries in the
+  institutions of global governance
+16.9-title: By 2030, provide legal identity for all, including birth registration
+16.a-title: Strengthen relevant national institutions, including through international
+  cooperation, for building capacity at all levels, in particular in developing countries,
+  to prevent violence and combat terrorism and crime
+16.b-title: Promote and enforce non-discriminatory laws and policies for sustainable
+  development
+17.1-title: Strengthen domestic resource mobilization, including through international
+  support to developing countries, to improve domestic capacity for tax and other
+  revenue collection
+17.10-title: Promote a universal, rules-based, open, non‐discriminatory and equitable
+  multilateral trading system under the World Trade Organization, including through
+  the conclusion of negotiations under its Doha Development Agenda
+17.11-title: Significantly increase the exports of developing countries, in particular
+  with a view to doubling the least developed countries’ share of global exports by
+  2020
+17.12-title: Realize timely implementation of duty-free and quota-free market access
+  on a lasting basis for all least developed countries, consistent with World Trade
+  Organization decisions, including by ensuring that preferential rules of origin
+  applicable to imports from least developed countries are transparent and simple,
+  and contribute to facilitating market access
+17.13-title: Enhance global macroeconomic stability, including through policy coordination
+  and policy coherence
+17.14-title: Enhance policy coherence for sustainable development
+17.15-title: Respect each country’s policy space and leadership to establish and implement
+  policies for poverty eradication and sustainable development
+17.16-title: Enhance the Global Partnership for Sustainable Development, complemented
+  by multi-stakeholder partnerships that mobilize and share knowledge, expertise,
+  technology and financial resources, to support the achievement of the Sustainable
+  Development Goals in all countries, in particular developing countries
+17.17-title: Encourage and promote effective public, public-private and civil society
+  partnerships, building on the experience and resourcing strategies of partnerships
+17.18-title: By 2020, enhance capacity-building support to developing countries, including
+  for least developed countries and small island developing States, to increase significantly
+  the availability of high-quality, timely and reliable data disaggregated by income,
+  gender, age, race, ethnicity, migratory status, disability, geographic location
+  and other characteristics relevant in national contexts
+17.19-title: By 2030, build on existing initiatives to develop measurements of progress
+  on sustainable development that complement gross domestic product, and support statistical
+  capacity-building in developing countries
+17.2-title: Developed countries to implement fully their official development assistance
+  commitments, including the commitment by many developed countries to achieve the
+  target of 0.7 per cent of gross national income for official development assistance
+  (ODA/GNI) to developing countries and 0.15 to 0.20 per cent of ODA/GNI to least
+  developed countries; ODA providers are encouraged to consider setting a target to
+  provide at least 0.20 per cent of ODA/GNI to least developed countries
+17.3-title: Mobilize additional financial resources for developing countries from
+  multiple sources
+17.4-title: Assist developing countries in attaining long-term debt sustainability
+  through coordinated policies aimed at fostering debt financing, debt relief and
+  debt restructuring, as appropriate, and address the external debt of highly indebted
+  poor countries to reduce debt distress
+17.5-title: Adopt and implement investment promotion regimes for least developed countries
+17.6-title: Enhance North-South, South-South and triangular regional and international
+  cooperation on and access to science, technology and innovation and enhance knowledge-sharing
+  on mutually agreed terms, including through improved coordination among existing
+  mechanisms, in particular at the United Nations level, and through a global technology
+  facilitation mechanism
+17.7-title: Promote the development, transfer, dissemination and diffusion of environmentally
+  sound technologies to developing countries on favourable terms, including on concessional
+  and preferential terms, as mutually agreed
+17.8-title: Fully operationalize the technology bank and science, technology and innovation
+  capacity-building mechanism for least developed countries by 2017 and enhance the
+  use of enabling technology, in particular information and communications technology
+17.9-title: Enhance international support for implementing effective and targeted
+  capacity-building in developing countries to support national plans to implement
+  all the Sustainable Development Goals, including through North-South, South-South
+  and triangular cooperation
+2.1-title: By 2030, end hunger and ensure access by all people, in particular the
+  poor and people in vulnerable situations, including infants, to safe, nutritious
+  and sufficient food all year round
+2.2-title: By 2030, end all forms of malnutrition, including achieving, by 2025, the
+  internationally agreed targets on stunting and wasting in children under 5 years
+  of age, and address the nutritional needs of adolescent girls, pregnant and lactating
+  women and older persons
+2.3-title: By 2030, double the agricultural productivity and incomes of small-scale
+  food producers, in particular women, indigenous peoples, family farmers, pastoralists
+  and fishers, including through secure and equal access to land, other productive
+  resources and inputs, knowledge, financial services, markets and opportunities for
+  value addition and non-farm employment
+2.4-title: By 2030, ensure sustainable food production systems and implement resilient
+  agricultural practices that increase productivity and production, that help maintain
+  ecosystems, that strengthen capacity for adaptation to climate change, extreme weather,
+  drought, flooding and other disasters and that progressively improve land and soil
+  quality
+2.5-title: By 2020, maintain the genetic diversity of seeds, cultivated plants and
+  farmed and domesticated animals and their related wild species, including through
+  soundly managed and diversified seed and plant banks at the national, regional and
+  international levels, and promote access to and fair and equitable sharing of benefits
+  arising from the utilization of genetic resources and associated traditional knowledge,
+  as internationally agreed
+2.a-title: Increase investment, including through enhanced international cooperation,
+  in rural infrastructure, agricultural research and extension services, technology
+  development and plant and livestock gene banks in order to enhance agricultural
+  productive capacity in developing countries, in particular least developed countries
+2.b-title: Correct and prevent trade restrictions and distortions in world agricultural
+  markets, including through the parallel elimination of all forms of agricultural
+  export subsidies and all export measures with equivalent effect, in accordance with
+  the mandate of the Doha Development Round
+2.c-title: Adopt measures to ensure the proper functioning of food commodity markets
+  and their derivatives and facilitate timely access to market information, including
+  on food reserves, in order to help limit extreme food price volatility
+3.1-title: By 2030, reduce the global maternal mortality ratio to less than 70 per
+  100,000 live births
+3.2-title: By 2030, end preventable deaths of newborns and children under 5 years
+  of age, with all countries aiming to reduce neonatal mortality to at least as low
+  as 12 per 1,000 live births and under‐5 mortality to at least as low as 25 per 1,000
+  live births
+3.3-title: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected
+  tropical diseases and combat hepatitis, water-borne diseases and other communicable
+  diseases
+3.4-title: By 2030, reduce by one third premature mortality from non-communicable
+  diseases through prevention and treatment and promote mental health and well-being
+3.5-title: Strengthen the prevention and treatment of substance abuse, including narcotic
+  drug abuse and harmful use of alcohol
+3.6-title: By 2020, halve the number of global deaths and injuries from road traffic
+  accidents
+3.7-title: By 2030, ensure universal access to sexual and reproductive health-care
+  services, including for family planning, information and education, and the integration
+  of reproductive health into national strategies and programmes
+3.8-title: Achieve universal health coverage, including financial risk protection,
+  access to quality essential health-care services and access to safe, effective,
+  quality and affordable essential medicines and vaccines for all
+3.9-title: By 2030, substantially reduce the number of deaths and illnesses from hazardous
+  chemicals and air, water and soil pollution and contamination
+3.a-title: Strengthen the implementation of the World Health Organization Framework
+  Convention on Tobacco Control in all countries, as appropriate
+3.b-title: Support the research and development of vaccines and medicines for the
+  communicable and non‐communicable diseases that primarily affect developing countries,
+  provide access to affordable essential medicines and vaccines, in accordance with
+  the Doha Declaration on the TRIPS Agreement and Public Health, which affirms the
+  right of developing countries to use to the full the provisions in the Agreement
+  on Trade-Related Aspects of Intellectual Property Rights regarding flexibilities
+  to protect public health, and, in particular, provide access to medicines for all
+3.c-title: Substantially increase health financing and the recruitment, development,
+  training and retention of the health workforce in developing countries, especially
+  in least developed countries and small island developing States
+3.d-title: Strengthen the capacity of all countries, in particular developing countries,
+  for early warning, risk reduction and management of national and global health risks
+4.1-title: By 2030, ensure that all girls and boys complete free, equitable and quality
+  primary and secondary education leading to relevant and effective learning outcomes
+4.2-title: By 2030, ensure that all girls and boys have access to quality early childhood
+  development, care and pre‐primary education so that they are ready for primary education
+4.3-title: By 2030, ensure equal access for all women and men to affordable and quality
+  technical, vocational and tertiary education, including university
+4.4-title: By 2030, substantially increase the number of youth and adults who have
+  relevant skills, including technical and vocational skills, for employment, decent
+  jobs and entrepreneurship
+4.5-title: By 2030, eliminate gender disparities in education and ensure equal access
+  to all levels of education and vocational training for the vulnerable, including
+  persons with disabilities, indigenous peoples and children in vulnerable situations
+4.6-title: By 2030, ensure that all youth and a substantial proportion of adults,
+  both men and women, achieve literacy and numeracy
+4.7-title: By 2030, ensure that all learners acquire the knowledge and skills needed
+  to promote sustainable development, including, among others, through education for
+  sustainable development and sustainable lifestyles, human rights, gender equality,
+  promotion of a culture of peace and non-violence, global citizenship and appreciation
+  of cultural diversity and of culture’s contribution to sustainable development
+4.a-title: Build and upgrade education facilities that are child, disability and gender
+  sensitive and provide safe, non-violent, inclusive and effective learning environments
+  for all
+4.b-title: By 2020, substantially expand globally the number of scholarships available
+  to developing countries, in particular least developed countries, small island developing
+  States and African countries, for enrolment in higher education, including vocational
+  training and information and communications technology, technical, engineering and
+  scientific programmes, in developed countries and other developing countries
+4.c-title: By 2030, substantially increase the supply of qualified teachers, including
+  through international cooperation for teacher training in developing countries,
+  especially least developed countries and small island developing States
+5.1-title: End all forms of discrimination against all women and girls everywhere
+5.2-title: Eliminate all forms of violence against all women and girls in the public
+  and private spheres, including trafficking and sexual and other types of exploitation
+5.3-title: Eliminate all harmful practices, such as child, early and forced marriage
+  and female genital mutilation
+5.4-title: Recognize and value unpaid care and domestic work through the provision
+  of public services, infrastructure and social protection policies and the promotion
+  of shared responsibility within the household and the family as nationally appropriate
+5.5-title: Ensure women’s full and effective participation and equal opportunities
+  for leadership at all levels of decision-making in political, economic and public
+  life
+5.6-title: Ensure universal access to sexual and reproductive health and reproductive
+  rights as agreed in accordance with the Programme of Action of the International
+  Conference on Population and Development and the Beijing Platform for Action and
+  the outcome documents of their review conferences
+5.a-title: Undertake reforms to give women equal rights to economic resources, as
+  well as access to ownership and control over land and other forms of property, financial
+  services, inheritance and natural resources, in accordance with national laws
+5.b-title: Enhance the use of enabling technology, in particular information and communications
+  technology, to promote the empowerment of women
+5.c-title: Adopt and strengthen sound policies and enforceable legislation for the
+  promotion of gender equality and the empowerment of all women and girls at all levels
+6.1-title: By 2030, achieve universal and equitable access to safe and affordable
+  drinking water for all
+6.2-title: By 2030, achieve access to adequate and equitable sanitation and hygiene
+  for all and end open defecation, paying special attention to the needs of women
+  and girls and those in vulnerable situations
+6.3-title: By 2030, improve water quality by reducing pollution, eliminating dumping
+  and minimizing release of hazardous chemicals and materials, halving the proportion
+  of untreated wastewater and substantially increasing recycling and safe reuse globally
+6.4-title: By 2030, substantially increase water-use efficiency across all sectors
+  and ensure sustainable withdrawals and supply of freshwater to address water scarcity
+  and substantially reduce the number of people suffering from water scarcity
+6.5-title: By 2030, implement integrated water resources management at all levels,
+  including through transboundary cooperation as appropriate
+6.6-title: By 2020, protect and restore water-related ecosystems, including mountains,
+  forests, wetlands, rivers, aquifers and lakes
+6.a-title: By 2030, expand international cooperation and capacity-building support
+  to developing countries in water- and sanitation-related activities and programmes,
+  including water harvesting, desalination, water efficiency, wastewater treatment,
+  recycling and reuse technologies
+6.b-title: Support and strengthen the participation of local communities in improving
+  water and sanitation management
+7.1-title: By 2030, ensure universal access to affordable, reliable and modern energy
+  services
+7.2-title: By 2030, increase substantially the share of renewable energy in the global
+  energy mix
+7.3-title: By 2030, double the global rate of improvement in energy efficiency
+7.a-title: By 2030, enhance international cooperation to facilitate access to clean
+  energy research and technology, including renewable energy, energy efficiency and
+  advanced and cleaner fossil-fuel technology, and promote investment in energy infrastructure
+  and clean energy technology
+7.b-title: By 2030, expand infrastructure and upgrade technology for supplying modern
+  and sustainable energy services for all in developing countries, in particular least
+  developed countries, small island developing States and landlocked developing countries,
+  in accordance with their respective programmes of support
+8.1-title: Sustain per capita economic growth in accordance with national circumstances
+  and, in particular, at least 7 per cent gross domestic product growth per annum
+  in the least developed countries
+8.10-title: Strengthen the capacity of domestic financial institutions to encourage
+  and expand access to banking, insurance and financial services for all
+8.2-title: Achieve higher levels of economic productivity through diversification,
+  technological upgrading and innovation, including through a focus on high-value
+  added and labour-intensive sectors
+8.3-title: Promote development-oriented policies that support productive activities,
+  decent job creation, entrepreneurship, creativity and innovation, and encourage
+  the formalization and growth of micro-, small- and medium-sized enterprises, including
+  through access to financial services
+8.4-title: Improve progressively, through 2030, global resource efficiency in consumption
+  and production and endeavour to decouple economic growth from environmental degradation,
+  in accordance with the 10‐Year Framework of Programmes on Sustainable Consumption
+  and Production, with developed countries taking the lead
+8.5-title: By 2030, achieve full and productive employment and decent work for all
+  women and men, including for young people and persons with disabilities, and equal
+  pay for work of equal value
+8.6-title: By 2020, substantially reduce the proportion of youth not in employment,
+  education or training
+8.7-title: Take immediate and effective measures to eradicate forced labour, end modern
+  slavery and human trafficking and secure the prohibition and elimination of the
+  worst forms of child labour, including recruitment and use of child soldiers, and
+  by 2025 end child labour in all its forms
+8.8-title: Protect labour rights and promote safe and secure working environments
+  for all workers, including migrant workers, in particular women migrants, and those
+  in precarious employment
+8.9-title: By 2030, devise and implement policies to promote sustainable tourism that
+  creates jobs and promotes local culture and products
+8.a-title: Increase Aid for Trade support for developing countries, in particular
+  least developed countries, including through the Enhanced Integrated Framework for
+  Trade-related Technical Assistance to Least Developed Countries
+8.b-title: By 2020, develop and operationalize a global strategy for youth employment
+  and implement the Global Jobs Pact of the International Labour Organization
+9.1-title: Develop quality, reliable, sustainable and resilient infrastructure, including
+  regional and transborder infrastructure, to support economic development and human
+  well-being, with a focus on affordable and equitable access for all
+9.2-title: Promote inclusive and sustainable industrialization and, by 2030, significantly
+  raise industry’s share of employment and gross domestic product, in line with national
+  circumstances, and double its share in least developed countries
+9.3-title: Increase the access of small-scale industrial and other enterprises, in
+  particular in developing countries, to financial services, including affordable
+  credit, and their integration into value chains and markets
+9.4-title: By 2030, upgrade infrastructure and retrofit industries to make them sustainable,
+  with increased resource-use efficiency and greater adoption of clean and environmentally
+  sound technologies and industrial processes, with all countries taking action in
+  accordance with their respective capabilities
+9.5-title: Enhance scientific research, upgrade the technological capabilities of
+  industrial sectors in all countries, in particular developing countries, including,
+  by 2030, encouraging innovation and substantially increasing the number of research
+  and development workers per 1 million people and public and private research and
+  development spending
+9.a-title: Facilitate sustainable and resilient infrastructure development in developing
+  countries through enhanced financial, technological and technical support to African
+  countries, least developed countries, landlocked developing countries and small
+  island developing States
+9.b-title: Support domestic technology development, research and innovation in developing
+  countries, including by ensuring a conducive policy environment for, inter alia,
+  industrial diversification and value addition to commodities
+9.c-title: Significantly increase access to information and communications technology
+  and strive to provide universal and affordable access to the Internet in least developed
+  countries by 2020


### PR DESCRIPTION
NOTE: This update will break any Open SDG sites below version 0.9.1 and below jekyll-open-sdg-plugins 0.0.14!

This update would be necessary for any sites to upgrade to Open SDG 0.9.1 or higher. Open SDG, as of version 0.9.1, expects the global translations (global_indicators, global_targets, global_goals) to be "flattened". Ie, instead of:
```
1:
  title: Foo
```
It should now be:
```
1-title: Foo
```
I've included in the PR the Python script that I ran to do this.

To be clear: merging this would need to be timed with an upgrade to both:
* open-sdg 0.9.1 or higher
* jekyll-open-sdg-plugins 0.0.14 or higher